### PR TITLE
gitignore VSCODE related directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 data/
 **/*.egg-info
 .python-version
+# VS CODE settings dir
+.vscode/


### PR DESCRIPTION
Added the `.vscode` directory to gitignore. People who are using VSCODE can use it without issues now. 