### PR TITLE
Allow examples w/o rendering

### DIFF
--- a/spinup/examples/pg_math/1_simple_pg.py
+++ b/spinup/examples/pg_math/1_simple_pg.py
@@ -63,7 +63,7 @@ def train(env_name='CartPole-v0', hidden_sizes=[32], lr=1e-2,
         while True:
 
             # rendering
-            if not(finished_rendering_this_epoch):
+            if (not finished_rendering_this_epoch) and render:
                 env.render()
 
             # save obs

--- a/spinup/examples/pg_math/2_rtg_pg.py
+++ b/spinup/examples/pg_math/2_rtg_pg.py
@@ -70,7 +70,7 @@ def train(env_name='CartPole-v0', hidden_sizes=[32], lr=1e-2,
         while True:
 
             # rendering
-            if not(finished_rendering_this_epoch):
+            if (not finished_rendering_this_epoch) and render:
                 env.render()
 
             # save obs


### PR DESCRIPTION
Making use of "--render" flag in the examples/pg_math as intended. 
Not using rendering allows examples to run faster.