### PR TITLE
Support pybullet for problem sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.*~
 __pycache__/
 *.pkl
+*.pyc
 data/
 **/*.egg-info
 .python-version

--- a/spinup/algos/ddpg/ddpg.py
+++ b/spinup/algos/ddpg/ddpg.py
@@ -42,9 +42,9 @@ class ReplayBuffer:
 Deep Deterministic Policy Gradient (DDPG)
 
 """
-def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
-         steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
-         polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
+def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
+         steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
+         polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
          act_noise=0.1, max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -52,8 +52,8 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols 
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
+        actor_critic: A function which takes in placeholder symbols
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -61,20 +61,20 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q``        (batch,)          | Gives the current estimate of Q* for 
+            ``q``        (batch,)          | Gives the current estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q_pi``     (batch,)          | Gives the composition of ``q`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q_pi``     (batch,)          | Gives the composition of ``q`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
             function you provided to DDPG.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -83,14 +83,14 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target 
-            networks. Target networks are updated towards main networks 
+        polyak (float): Interpolation factor in polyak averaging for target
+            networks. Target networks are updated towards main networks
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow 
+            .. math:: \\theta_{\\text{targ}} \\leftarrow
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -102,7 +102,7 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to 
+        act_noise (float): Stddev for Gaussian exploration noise added to
             policy at training time. (At test time, no noise is added.)
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -136,10 +136,10 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q, q_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-    
+
     # Target networks
     with tf.variable_scope('target'):
-        # Note that the action placeholder going to actor_critic here is 
+        # Note that the action placeholder going to actor_critic here is
         # irrelevant, because we only need q_targ(s, pi_targ(s)).
         pi_targ, _, q_pi_targ  = actor_critic(x2_ph, a_ph, **ac_kwargs)
 
@@ -179,7 +179,7 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, outputs={'pi': pi, 'q': q})
 
     def get_action(o, noise_scale):
-        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})
+        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})[0]
         a += noise_scale * np.random.randn(act_dim)
         return np.clip(a, -act_limit, act_limit)
 
@@ -202,8 +202,8 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards, 
-        use the learned policy (with some noise, via act_noise). 
+        from a uniform distribution for better exploration. Afterwards,
+        use the learned policy (with some noise, via act_noise).
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -223,7 +223,7 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update 
+        # Super critical, easy to overlook step: make sure to update
         # most recent observation!
         o = o2
 

--- a/spinup/algos/ddpg/ddpg.py
+++ b/spinup/algos/ddpg/ddpg.py
@@ -42,9 +42,9 @@ class ReplayBuffer:
 Deep Deterministic Policy Gradient (DDPG)
 
 """
-def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
-         steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
-         polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
+def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
+         steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
+         polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
          act_noise=0.1, max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -52,8 +52,8 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main
+        actor_critic: A function which takes in placeholder symbols 
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -61,20 +61,20 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q``        (batch,)          | Gives the current estimate of Q* for
+            ``q``        (batch,)          | Gives the current estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q_pi``     (batch,)          | Gives the composition of ``q`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q_pi``     (batch,)          | Gives the composition of ``q`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
             function you provided to DDPG.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -83,14 +83,14 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target
-            networks. Target networks are updated towards main networks
+        polyak (float): Interpolation factor in polyak averaging for target 
+            networks. Target networks are updated towards main networks 
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow
+            .. math:: \\theta_{\\text{targ}} \\leftarrow 
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -102,7 +102,7 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to
+        act_noise (float): Stddev for Gaussian exploration noise added to 
             policy at training time. (At test time, no noise is added.)
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -136,10 +136,10 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q, q_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-
+    
     # Target networks
     with tf.variable_scope('target'):
-        # Note that the action placeholder going to actor_critic here is
+        # Note that the action placeholder going to actor_critic here is 
         # irrelevant, because we only need q_targ(s, pi_targ(s)).
         pi_targ, _, q_pi_targ  = actor_critic(x2_ph, a_ph, **ac_kwargs)
 
@@ -202,8 +202,8 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards,
-        use the learned policy (with some noise, via act_noise).
+        from a uniform distribution for better exploration. Afterwards, 
+        use the learned policy (with some noise, via act_noise). 
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -223,7 +223,7 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update
+        # Super critical, easy to overlook step: make sure to update 
         # most recent observation!
         o = o2
 

--- a/spinup/algos/sac/sac.py
+++ b/spinup/algos/sac/sac.py
@@ -44,9 +44,9 @@ Soft Actor-Critic
 (With slight variations that bring it closer to TD3)
 
 """
-def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
-        polyak=0.995, lr=1e-3, alpha=0.2, batch_size=100, start_steps=10000,
+def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
+        polyak=0.995, lr=1e-3, alpha=0.2, batch_size=100, start_steps=10000, 
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -54,8 +54,8 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main
+        actor_critic: A function which takes in placeholder symbols 
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -63,35 +63,35 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``mu``       (batch, act_dim)  | Computes mean actions from policy
                                            | given states.
-            ``pi``       (batch, act_dim)  | Samples actions from policy given
+            ``pi``       (batch, act_dim)  | Samples actions from policy given 
                                            | states.
             ``logp_pi``  (batch,)          | Gives log probability, according to
                                            | the policy, of the action sampled by
                                            | ``pi``. Critical: must be differentiable
                                            | with respect to policy parameters all
                                            | the way through action sampling.
-            ``q1``       (batch,)          | Gives one estimate of Q* for
+            ``q1``       (batch,)          | Gives one estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for
+            ``q2``       (batch,)          | Gives another estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q1(x, pi(x)).
-            ``q2_pi``    (batch,)          | Gives the composition of ``q2`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q2_pi``    (batch,)          | Gives the composition of ``q2`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q2(x, pi(x)).
             ``v``        (batch,)          | Gives the value estimate for states
-                                           | in ``x_ph``.
+                                           | in ``x_ph``. 
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
             function you provided to SAC.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -100,19 +100,19 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target
-            networks. Target networks are updated towards main networks
+        polyak (float): Interpolation factor in polyak averaging for target 
+            networks. Target networks are updated towards main networks 
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow
+            .. math:: \\theta_{\\text{targ}} \\leftarrow 
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
             close to 1.)
 
         lr (float): Learning rate (used for both policy and value learning).
 
-        alpha (float): Entropy regularization coefficient. (Equivalent to
+        alpha (float): Entropy regularization coefficient. (Equivalent to 
             inverse of reward scale in the original SAC paper.)
 
         batch_size (int): Minibatch size for SGD.
@@ -151,7 +151,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         mu, pi, logp_pi, q1, q2, q1_pi, q2_pi, v = actor_critic(x_ph, a_ph, **ac_kwargs)
-
+    
     # Target value network
     with tf.variable_scope('target'):
         _, _, _, _, _, _, _, v_targ  = actor_critic(x2_ph, a_ph, **ac_kwargs)
@@ -160,7 +160,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     replay_buffer = ReplayBuffer(obs_dim=obs_dim, act_dim=act_dim, size=replay_size)
 
     # Count variables
-    var_counts = tuple(core.count_vars(scope) for scope in
+    var_counts = tuple(core.count_vars(scope) for scope in 
                        ['main/pi', 'main/q1', 'main/q2', 'main/v', 'main'])
     print(('\nNumber of parameters: \t pi: %d, \t' + \
            'q1: %d, \t q2: %d, \t v: %d, \t total: %d\n')%var_counts)
@@ -179,7 +179,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     v_loss = 0.5 * tf.reduce_mean((v_backup - v)**2)
     value_loss = q1_loss + q2_loss + v_loss
 
-    # Policy train op
+    # Policy train op 
     # (has to be separate from value train op, because q1_pi appears in pi_loss)
     pi_optimizer = tf.train.AdamOptimizer(learning_rate=lr)
     train_pi_op = pi_optimizer.minimize(pi_loss, var_list=get_vars('main/pi'))
@@ -198,7 +198,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
                                   for v_main, v_targ in zip(get_vars('main'), get_vars('target'))])
 
     # All ops to call during one training step
-    step_ops = [pi_loss, q1_loss, q2_loss, v_loss, q1, q2, v, logp_pi,
+    step_ops = [pi_loss, q1_loss, q2_loss, v_loss, q1, q2, v, logp_pi, 
                 train_pi_op, train_value_op, target_update]
 
     # Initializing targets to match main variables
@@ -210,7 +210,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     sess.run(target_init)
 
     # Setup model saving
-    logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph},
+    logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, 
                                 outputs={'mu': mu, 'pi': pi, 'q1': q1, 'q2': q2, 'v': v})
 
     def get_action(o, deterministic=False):
@@ -222,7 +222,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         for j in range(n):
             o, r, d, ep_ret, ep_len = test_env.reset(), 0, False, 0, 0
             while not(d or (ep_len == max_ep_len)):
-                # Take deterministic actions at test time
+                # Take deterministic actions at test time 
                 o, r, d, _ = test_env.step(get_action(o, True))
                 ep_ret += r
                 ep_len += 1
@@ -237,8 +237,8 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards,
-        use the learned policy.
+        from a uniform distribution for better exploration. Afterwards, 
+        use the learned policy. 
         """
         if t > start_steps:
             a = get_action(o)
@@ -258,7 +258,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update
+        # Super critical, easy to overlook step: make sure to update 
         # most recent observation!
         o = o2
 
@@ -303,9 +303,9 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             logger.log_tabular('EpLen', average_only=True)
             logger.log_tabular('TestEpLen', average_only=True)
             logger.log_tabular('TotalEnvInteracts', t)
-            logger.log_tabular('Q1Vals', with_min_and_max=True)
-            logger.log_tabular('Q2Vals', with_min_and_max=True)
-            logger.log_tabular('VVals', with_min_and_max=True)
+            logger.log_tabular('Q1Vals', with_min_and_max=True) 
+            logger.log_tabular('Q2Vals', with_min_and_max=True) 
+            logger.log_tabular('VVals', with_min_and_max=True) 
             logger.log_tabular('LogPi', with_min_and_max=True)
             logger.log_tabular('LossPi', average_only=True)
             logger.log_tabular('LossQ1', average_only=True)

--- a/spinup/algos/sac/sac.py
+++ b/spinup/algos/sac/sac.py
@@ -44,9 +44,9 @@ Soft Actor-Critic
 (With slight variations that bring it closer to TD3)
 
 """
-def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
-        polyak=0.995, lr=1e-3, alpha=0.2, batch_size=100, start_steps=10000, 
+def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
+        polyak=0.995, lr=1e-3, alpha=0.2, batch_size=100, start_steps=10000,
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -54,8 +54,8 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols 
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
+        actor_critic: A function which takes in placeholder symbols
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -63,35 +63,35 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``mu``       (batch, act_dim)  | Computes mean actions from policy
                                            | given states.
-            ``pi``       (batch, act_dim)  | Samples actions from policy given 
+            ``pi``       (batch, act_dim)  | Samples actions from policy given
                                            | states.
             ``logp_pi``  (batch,)          | Gives log probability, according to
                                            | the policy, of the action sampled by
                                            | ``pi``. Critical: must be differentiable
                                            | with respect to policy parameters all
                                            | the way through action sampling.
-            ``q1``       (batch,)          | Gives one estimate of Q* for 
+            ``q1``       (batch,)          | Gives one estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for 
+            ``q2``       (batch,)          | Gives another estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q1(x, pi(x)).
-            ``q2_pi``    (batch,)          | Gives the composition of ``q2`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q2_pi``    (batch,)          | Gives the composition of ``q2`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q2(x, pi(x)).
             ``v``        (batch,)          | Gives the value estimate for states
-                                           | in ``x_ph``. 
+                                           | in ``x_ph``.
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
             function you provided to SAC.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -100,19 +100,19 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target 
-            networks. Target networks are updated towards main networks 
+        polyak (float): Interpolation factor in polyak averaging for target
+            networks. Target networks are updated towards main networks
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow 
+            .. math:: \\theta_{\\text{targ}} \\leftarrow
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
             close to 1.)
 
         lr (float): Learning rate (used for both policy and value learning).
 
-        alpha (float): Entropy regularization coefficient. (Equivalent to 
+        alpha (float): Entropy regularization coefficient. (Equivalent to
             inverse of reward scale in the original SAC paper.)
 
         batch_size (int): Minibatch size for SGD.
@@ -151,7 +151,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         mu, pi, logp_pi, q1, q2, q1_pi, q2_pi, v = actor_critic(x_ph, a_ph, **ac_kwargs)
-    
+
     # Target value network
     with tf.variable_scope('target'):
         _, _, _, _, _, _, _, v_targ  = actor_critic(x2_ph, a_ph, **ac_kwargs)
@@ -160,7 +160,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     replay_buffer = ReplayBuffer(obs_dim=obs_dim, act_dim=act_dim, size=replay_size)
 
     # Count variables
-    var_counts = tuple(core.count_vars(scope) for scope in 
+    var_counts = tuple(core.count_vars(scope) for scope in
                        ['main/pi', 'main/q1', 'main/q2', 'main/v', 'main'])
     print(('\nNumber of parameters: \t pi: %d, \t' + \
            'q1: %d, \t q2: %d, \t v: %d, \t total: %d\n')%var_counts)
@@ -179,7 +179,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     v_loss = 0.5 * tf.reduce_mean((v_backup - v)**2)
     value_loss = q1_loss + q2_loss + v_loss
 
-    # Policy train op 
+    # Policy train op
     # (has to be separate from value train op, because q1_pi appears in pi_loss)
     pi_optimizer = tf.train.AdamOptimizer(learning_rate=lr)
     train_pi_op = pi_optimizer.minimize(pi_loss, var_list=get_vars('main/pi'))
@@ -198,7 +198,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
                                   for v_main, v_targ in zip(get_vars('main'), get_vars('target'))])
 
     # All ops to call during one training step
-    step_ops = [pi_loss, q1_loss, q2_loss, v_loss, q1, q2, v, logp_pi, 
+    step_ops = [pi_loss, q1_loss, q2_loss, v_loss, q1, q2, v, logp_pi,
                 train_pi_op, train_value_op, target_update]
 
     # Initializing targets to match main variables
@@ -210,19 +210,19 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     sess.run(target_init)
 
     # Setup model saving
-    logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, 
+    logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph},
                                 outputs={'mu': mu, 'pi': pi, 'q1': q1, 'q2': q2, 'v': v})
 
     def get_action(o, deterministic=False):
         act_op = mu if deterministic else pi
-        return sess.run(act_op, feed_dict={x_ph: o.reshape(1,-1)})
+        return sess.run(act_op, feed_dict={x_ph: o.reshape(1,-1)})[0]
 
     def test_agent(n=10):
         global sess, mu, pi, q1, q2, q1_pi, q2_pi
         for j in range(n):
             o, r, d, ep_ret, ep_len = test_env.reset(), 0, False, 0, 0
             while not(d or (ep_len == max_ep_len)):
-                # Take deterministic actions at test time 
+                # Take deterministic actions at test time
                 o, r, d, _ = test_env.step(get_action(o, True))
                 ep_ret += r
                 ep_len += 1
@@ -237,8 +237,8 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards, 
-        use the learned policy. 
+        from a uniform distribution for better exploration. Afterwards,
+        use the learned policy.
         """
         if t > start_steps:
             a = get_action(o)
@@ -258,7 +258,7 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update 
+        # Super critical, easy to overlook step: make sure to update
         # most recent observation!
         o = o2
 
@@ -303,9 +303,9 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             logger.log_tabular('EpLen', average_only=True)
             logger.log_tabular('TestEpLen', average_only=True)
             logger.log_tabular('TotalEnvInteracts', t)
-            logger.log_tabular('Q1Vals', with_min_and_max=True) 
-            logger.log_tabular('Q2Vals', with_min_and_max=True) 
-            logger.log_tabular('VVals', with_min_and_max=True) 
+            logger.log_tabular('Q1Vals', with_min_and_max=True)
+            logger.log_tabular('Q2Vals', with_min_and_max=True)
+            logger.log_tabular('VVals', with_min_and_max=True)
             logger.log_tabular('LogPi', with_min_and_max=True)
             logger.log_tabular('LossPi', average_only=True)
             logger.log_tabular('LossQ1', average_only=True)

--- a/spinup/algos/td3/td3.py
+++ b/spinup/algos/td3/td3.py
@@ -42,10 +42,10 @@ class ReplayBuffer:
 TD3 (Twin Delayed DDPG)
 
 """
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -53,8 +53,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main
+        actor_critic: A function which takes in placeholder symbols 
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -62,23 +62,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for
+            ``q1``       (batch,)          | Gives one estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for
+            ``q2``       (batch,)          | Gives another estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -87,14 +87,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target
-            networks. Target networks are updated towards main networks
+        polyak (float): Interpolation factor in polyak averaging for target 
+            networks. Target networks are updated towards main networks 
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow
+            .. math:: \\theta_{\\text{targ}} \\leftarrow 
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -106,16 +106,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to
+        act_noise (float): Stddev for Gaussian exploration noise added to 
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target
+        target_noise (float): Stddev for smoothing noise added to target 
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy
+        noise_clip (float): Limit for absolute value of target policy 
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every
+        policy_delay (int): Policy will only be updated once every 
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -149,11 +149,11 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q1, q2, q1_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-
+    
     # Target policy network
     with tf.variable_scope('target'):
         pi_targ, _, _, _  = actor_critic(x2_ph, a_ph, **ac_kwargs)
-
+    
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -228,8 +228,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards,
-        use the learned policy (with some noise, via act_noise).
+        from a uniform distribution for better exploration. Afterwards, 
+        use the learned policy (with some noise, via act_noise). 
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -249,7 +249,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update
+        # Super critical, easy to overlook step: make sure to update 
         # most recent observation!
         o = o2
 
@@ -318,7 +318,7 @@ if __name__ == '__main__':
 
     from spinup.utils.run_utils import setup_logger_kwargs
     logger_kwargs = setup_logger_kwargs(args.exp_name, args.seed)
-
+    
     td3(lambda : gym.make(args.env), actor_critic=core.mlp_actor_critic,
         ac_kwargs=dict(hidden_sizes=[args.hid]*args.l),
         gamma=args.gamma, seed=args.seed, epochs=args.epochs,

--- a/spinup/algos/td3/td3.py
+++ b/spinup/algos/td3/td3.py
@@ -42,10 +42,10 @@ class ReplayBuffer:
 TD3 (Twin Delayed DDPG)
 
 """
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -53,8 +53,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols 
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
+        actor_critic: A function which takes in placeholder symbols
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -62,23 +62,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for 
+            ``q1``       (batch,)          | Gives one estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for 
+            ``q2``       (batch,)          | Gives another estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -87,14 +87,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target 
-            networks. Target networks are updated towards main networks 
+        polyak (float): Interpolation factor in polyak averaging for target
+            networks. Target networks are updated towards main networks
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow 
+            .. math:: \\theta_{\\text{targ}} \\leftarrow
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -106,16 +106,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to 
+        act_noise (float): Stddev for Gaussian exploration noise added to
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target 
+        target_noise (float): Stddev for smoothing noise added to target
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy 
+        noise_clip (float): Limit for absolute value of target policy
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every 
+        policy_delay (int): Policy will only be updated once every
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -149,11 +149,11 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q1, q2, q1_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-    
+
     # Target policy network
     with tf.variable_scope('target'):
         pi_targ, _, _, _  = actor_critic(x2_ph, a_ph, **ac_kwargs)
-    
+
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -205,7 +205,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, outputs={'pi': pi, 'q1': q1, 'q2': q2})
 
     def get_action(o, noise_scale):
-        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})
+        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})[0]
         a += noise_scale * np.random.randn(act_dim)
         return np.clip(a, -act_limit, act_limit)
 
@@ -228,8 +228,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards, 
-        use the learned policy (with some noise, via act_noise). 
+        from a uniform distribution for better exploration. Afterwards,
+        use the learned policy (with some noise, via act_noise).
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -249,7 +249,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update 
+        # Super critical, easy to overlook step: make sure to update
         # most recent observation!
         o = o2
 
@@ -318,7 +318,7 @@ if __name__ == '__main__':
 
     from spinup.utils.run_utils import setup_logger_kwargs
     logger_kwargs = setup_logger_kwargs(args.exp_name, args.seed)
-    
+
     td3(lambda : gym.make(args.env), actor_critic=core.mlp_actor_critic,
         ac_kwargs=dict(hidden_sizes=[args.hid]*args.l),
         gamma=args.gamma, seed=args.seed, epochs=args.epochs,

--- a/spinup/exercises/problem_set_1/exercise1_2.py
+++ b/spinup/exercises/problem_set_1/exercise1_2.py
@@ -6,7 +6,7 @@ from spinup.exercises.problem_set_1 import exercise1_1
 
 Exercise 1.2: PPO Gaussian Policy
 
-Implement an MLP diagonal Gaussian policy for PPO.
+Implement an MLP diagonal Gaussian policy for PPO. 
 
 Log-likelihoods will be computed using your answer to Exercise 1.1,
 so make sure to complete that exercise before beginning this one.
@@ -62,13 +62,13 @@ def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, actio
             environment this agent will interact with.
 
     Returns:
-        pi: A symbol for sampling stochastic actions from a Gaussian
+        pi: A symbol for sampling stochastic actions from a Gaussian 
             distribution.
 
-        logp: A symbol for computing log-likelihoods of actions from a Gaussian
+        logp: A symbol for computing log-likelihoods of actions from a Gaussian 
             distribution.
 
-        logp_pi: A symbol for computing log-likelihoods of actions in pi from a
+        logp_pi: A symbol for computing log-likelihoods of actions in pi from a 
             Gaussian distribution.
 
     """
@@ -77,9 +77,9 @@ def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, actio
     #   YOUR CODE HERE    #
     #                     #
     #######################
-    # mu =
-    # log_std =
-    # pi =
+    # mu = 
+    # log_std = 
+    # pi = 
 
     logp = exercise1_1.gaussian_likelihood(a, mu, log_std)
     logp_pi = exercise1_1.gaussian_likelihood(pi, mu, log_std)

--- a/spinup/exercises/problem_set_1/exercise1_2.py
+++ b/spinup/exercises/problem_set_1/exercise1_2.py
@@ -6,7 +6,7 @@ from spinup.exercises.problem_set_1 import exercise1_1
 
 Exercise 1.2: PPO Gaussian Policy
 
-Implement an MLP diagonal Gaussian policy for PPO. 
+Implement an MLP diagonal Gaussian policy for PPO.
 
 Log-likelihoods will be computed using your answer to Exercise 1.1,
 so make sure to complete that exercise before beginning this one.
@@ -62,13 +62,13 @@ def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, actio
             environment this agent will interact with.
 
     Returns:
-        pi: A symbol for sampling stochastic actions from a Gaussian 
+        pi: A symbol for sampling stochastic actions from a Gaussian
             distribution.
 
-        logp: A symbol for computing log-likelihoods of actions from a Gaussian 
+        logp: A symbol for computing log-likelihoods of actions from a Gaussian
             distribution.
 
-        logp_pi: A symbol for computing log-likelihoods of actions in pi from a 
+        logp_pi: A symbol for computing log-likelihoods of actions in pi from a
             Gaussian distribution.
 
     """
@@ -77,9 +77,9 @@ def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, actio
     #   YOUR CODE HERE    #
     #                     #
     #######################
-    # mu = 
-    # log_std = 
-    # pi = 
+    # mu =
+    # log_std =
+    # pi =
 
     logp = exercise1_1.gaussian_likelihood(a, mu, log_std)
     logp_pi = exercise1_1.gaussian_likelihood(pi, mu, log_std)
@@ -93,14 +93,16 @@ if __name__ == '__main__':
 
     from spinup import ppo
     from spinup.exercises.common import print_result
+    from spinup.user_config import INVERTEDPENDULUM_ENV
     import gym
     import os
     import pandas as pd
     import psutil
     import time
+    import pybullet_envs
 
     logdir = "/tmp/experiments/%i"%int(time.time())
-    ppo(env_fn = lambda : gym.make('InvertedPendulum-v2'),
+    ppo(env_fn = lambda : gym.make(INVERTEDPENDULUM_ENV),
         ac_kwargs=dict(policy=mlp_gaussian_policy, hidden_sizes=(64,)),
         steps_per_epoch=4000, epochs=20, logger_kwargs=dict(output_dir=logdir))
 

--- a/spinup/exercises/problem_set_1/exercise1_3.py
+++ b/spinup/exercises/problem_set_1/exercise1_3.py
@@ -6,6 +6,8 @@ from spinup.algos.td3 import core
 from spinup.algos.td3.td3 import td3 as true_td3
 from spinup.algos.td3.core import get_vars
 from spinup.utils.logx import EpochLogger
+from spinup.user_config import HALFCHEETAH_ENV
+import pybullet_envs
 
 """
 
@@ -16,7 +18,7 @@ Implement the core computation graph for the TD3 algorithm.
 As starter code, you are given the entirety of the TD3 algorithm except
 for the computation graph. Find "YOUR CODE HERE" to begin.
 
-To clarify: you will not write an "actor_critic" function for this 
+To clarify: you will not write an "actor_critic" function for this
 exercise. But you will use one to build the graph for computing the
 TD3 updates.
 
@@ -57,10 +59,10 @@ class ReplayBuffer:
 TD3 (Twin Delayed DDPG)
 
 """
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -68,8 +70,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols 
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
+        actor_critic: A function which takes in placeholder symbols
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -77,23 +79,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for 
+            ``q1``       (batch,)          | Gives one estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for 
+            ``q2``       (batch,)          | Gives another estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -102,14 +104,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target 
-            networks. Target networks are updated towards main networks 
+        polyak (float): Interpolation factor in polyak averaging for target
+            networks. Target networks are updated towards main networks
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow 
+            .. math:: \\theta_{\\text{targ}} \\leftarrow
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -121,16 +123,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to 
+        act_noise (float): Stddev for Gaussian exploration noise added to
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target 
+        target_noise (float): Stddev for smoothing noise added to target
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy 
+        noise_clip (float): Limit for absolute value of target policy
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every 
+        policy_delay (int): Policy will only be updated once every
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -174,9 +176,9 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         #   YOUR CODE HERE    #
         #                     #
         #######################
-        # pi, q1, q2, q1_pi = 
+        # pi, q1, q2, q1_pi =
         pass
-    
+
     # Target policy network
     with tf.variable_scope('target'):
         #######################
@@ -186,7 +188,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         #######################
         # pi_targ =
         pass
-    
+
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -225,10 +227,10 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     #   YOUR CODE HERE    #
     #                     #
     #######################
-    # pi_loss = 
-    # q1_loss = 
-    # q2_loss = 
-    # q_loss = 
+    # pi_loss =
+    # q1_loss =
+    # q2_loss =
+    # q_loss =
 
     #=========================================================================#
     #                                                                         #
@@ -281,8 +283,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards, 
-        use the learned policy (with some noise, via act_noise). 
+        from a uniform distribution for better exploration. Afterwards,
+        use the learned policy (with some noise, via act_noise).
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -302,7 +304,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update 
+        # Super critical, easy to overlook step: make sure to update
         # most recent observation!
         o = o2
 
@@ -360,7 +362,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('--env', type=str, default='HalfCheetah-v2')
+    parser.add_argument('--env', type=str, default=HALFCHEETAH_ENV)
     parser.add_argument('--seed', '-s', type=int, default=0)
     parser.add_argument('--exp_name', type=str, default='ex13-td3')
     parser.add_argument('--use_soln', action='store_true')
@@ -370,15 +372,15 @@ if __name__ == '__main__':
     logger_kwargs = setup_logger_kwargs(args.exp_name + '-' + args.env.lower(), args.seed)
 
     all_kwargs = dict(
-        env_fn=lambda : gym.make(args.env), 
+        env_fn=lambda : gym.make(args.env),
         actor_critic=core.mlp_actor_critic,
-        ac_kwargs=dict(hidden_sizes=[128,128]), 
+        ac_kwargs=dict(hidden_sizes=[128,128]),
         max_ep_len=150,
-        seed=args.seed, 
+        seed=args.seed,
         logger_kwargs=logger_kwargs,
         epochs=10
         )
-    
+
     if args.use_soln:
         true_td3(**all_kwargs)
     else:

--- a/spinup/exercises/problem_set_1/exercise1_3.py
+++ b/spinup/exercises/problem_set_1/exercise1_3.py
@@ -260,7 +260,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, outputs={'pi': pi, 'q1': q1, 'q2': q2})
 
     def get_action(o, noise_scale):
-        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})
+        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})[0]
         a += noise_scale * np.random.randn(act_dim)
         return np.clip(a, -act_limit, act_limit)
 

--- a/spinup/exercises/problem_set_1/exercise1_3.py
+++ b/spinup/exercises/problem_set_1/exercise1_3.py
@@ -2,12 +2,12 @@ import numpy as np
 import tensorflow as tf
 import gym
 import time
+import pybullet_envs
 from spinup.algos.td3 import core
 from spinup.algos.td3.td3 import td3 as true_td3
 from spinup.algos.td3.core import get_vars
 from spinup.utils.logx import EpochLogger
 from spinup.user_config import HALFCHEETAH_ENV
-import pybullet_envs
 
 """
 
@@ -18,7 +18,7 @@ Implement the core computation graph for the TD3 algorithm.
 As starter code, you are given the entirety of the TD3 algorithm except
 for the computation graph. Find "YOUR CODE HERE" to begin.
 
-To clarify: you will not write an "actor_critic" function for this
+To clarify: you will not write an "actor_critic" function for this 
 exercise. But you will use one to build the graph for computing the
 TD3 updates.
 
@@ -59,10 +59,10 @@ class ReplayBuffer:
 TD3 (Twin Delayed DDPG)
 
 """
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
         max_ep_len=1000, logger_kwargs=dict(), save_freq=1):
     """
 
@@ -70,8 +70,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main
+        actor_critic: A function which takes in placeholder symbols 
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -79,23 +79,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for
+            ``q1``       (batch,)          | Gives one estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for
+            ``q2``       (batch,)          | Gives another estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -104,14 +104,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target
-            networks. Target networks are updated towards main networks
+        polyak (float): Interpolation factor in polyak averaging for target 
+            networks. Target networks are updated towards main networks 
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow
+            .. math:: \\theta_{\\text{targ}} \\leftarrow 
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -123,16 +123,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to
+        act_noise (float): Stddev for Gaussian exploration noise added to 
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target
+        target_noise (float): Stddev for smoothing noise added to target 
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy
+        noise_clip (float): Limit for absolute value of target policy 
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every
+        policy_delay (int): Policy will only be updated once every 
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -176,9 +176,9 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         #   YOUR CODE HERE    #
         #                     #
         #######################
-        # pi, q1, q2, q1_pi =
+        # pi, q1, q2, q1_pi = 
         pass
-
+    
     # Target policy network
     with tf.variable_scope('target'):
         #######################
@@ -188,7 +188,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         #######################
         # pi_targ =
         pass
-
+    
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -227,10 +227,10 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     #   YOUR CODE HERE    #
     #                     #
     #######################
-    # pi_loss =
-    # q1_loss =
-    # q2_loss =
-    # q_loss =
+    # pi_loss = 
+    # q1_loss = 
+    # q2_loss = 
+    # q_loss = 
 
     #=========================================================================#
     #                                                                         #
@@ -283,8 +283,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards,
-        use the learned policy (with some noise, via act_noise).
+        from a uniform distribution for better exploration. Afterwards, 
+        use the learned policy (with some noise, via act_noise). 
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -304,7 +304,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update
+        # Super critical, easy to overlook step: make sure to update 
         # most recent observation!
         o = o2
 
@@ -372,15 +372,15 @@ if __name__ == '__main__':
     logger_kwargs = setup_logger_kwargs(args.exp_name + '-' + args.env.lower(), args.seed)
 
     all_kwargs = dict(
-        env_fn=lambda : gym.make(args.env),
+        env_fn=lambda : gym.make(args.env), 
         actor_critic=core.mlp_actor_critic,
-        ac_kwargs=dict(hidden_sizes=[128,128]),
+        ac_kwargs=dict(hidden_sizes=[128,128]), 
         max_ep_len=150,
-        seed=args.seed,
+        seed=args.seed, 
         logger_kwargs=logger_kwargs,
         epochs=10
         )
-
+    
     if args.use_soln:
         true_td3(**all_kwargs)
     else:

--- a/spinup/exercises/problem_set_2/exercise2_2.py
+++ b/spinup/exercises/problem_set_2/exercise2_2.py
@@ -1,5 +1,6 @@
 from spinup.algos.ddpg.core import mlp, mlp_actor_critic
 from spinup.utils.run_utils import ExperimentGrid
+from spinup.user_config import HALFCHEETAH_ENV
 from spinup import ddpg
 import numpy as np
 import tensorflow as tf
@@ -19,7 +20,7 @@ You do NOT need to write code for this exercise.
 """
 Bugged Actor-Critic
 """
-def bugged_mlp_actor_critic(x, a, hidden_sizes=(400,300), activation=tf.nn.relu, 
+def bugged_mlp_actor_critic(x, a, hidden_sizes=(400,300), activation=tf.nn.relu,
                             output_activation=tf.tanh, action_space=None):
     act_dim = a.shape.as_list()[-1]
     act_limit = action_space.high[0]
@@ -35,7 +36,7 @@ def bugged_mlp_actor_critic(x, a, hidden_sizes=(400,300), activation=tf.nn.relu,
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('--env', type=str, default='HalfCheetah-v2')
+    parser.add_argument('--env', type=str, default=HALFCHEETAH_ENV)
     parser.add_argument('--h', type=int, default=300)
     parser.add_argument('--l', type=int, default=1)
     parser.add_argument('--num_runs', '-n', type=int, default=3)
@@ -45,7 +46,7 @@ if __name__ == '__main__':
 
     def ddpg_with_actor_critic(bugged, **kwargs):
         actor_critic = bugged_mlp_actor_critic if bugged else mlp_actor_critic
-        return ddpg(actor_critic=actor_critic, 
+        return ddpg(actor_critic=actor_critic,
                     ac_kwargs=dict(hidden_sizes=[args.h]*args.l),
                     start_steps=5000,
                     max_ep_len=150,

--- a/spinup/exercises/problem_set_2/exercise2_3.py
+++ b/spinup/exercises/problem_set_2/exercise2_3.py
@@ -7,6 +7,7 @@ from spinup.algos.td3.td3 import ReplayBuffer
 from spinup.algos.td3.core import get_vars
 from spinup.utils.logx import EpochLogger
 from spinup.utils.run_utils import ExperimentGrid
+from spinup.user_config import HALFCHEETAH_ENV
 
 
 """
@@ -14,18 +15,18 @@ from spinup.utils.run_utils import ExperimentGrid
 Exercise 2.3: Details Matter
 
 In this exercise, you will run TD3 with a tiny implementation difference,
-pertaining to how target actions are calculated. Your goal is to determine 
+pertaining to how target actions are calculated. Your goal is to determine
 whether or not there is any change in performance, and if so, explain why.
 
 You do NOT need to write code for this exercise.
 
 """
 
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
-        max_ep_len=1000, logger_kwargs=dict(), save_freq=1, 
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
+        max_ep_len=1000, logger_kwargs=dict(), save_freq=1,
         remove_action_clip=False):
     """
 
@@ -33,8 +34,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols 
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
+        actor_critic: A function which takes in placeholder symbols
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -42,23 +43,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for 
+            ``q1``       (batch,)          | Gives one estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for 
+            ``q2``       (batch,)          | Gives another estimate of Q* for
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
-                                           | ``pi`` for states in ``x_ph``: 
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
+                                           | ``pi`` for states in ``x_ph``:
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -67,14 +68,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target 
-            networks. Target networks are updated towards main networks 
+        polyak (float): Interpolation factor in polyak averaging for target
+            networks. Target networks are updated towards main networks
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow 
+            .. math:: \\theta_{\\text{targ}} \\leftarrow
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -86,16 +87,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to 
+        act_noise (float): Stddev for Gaussian exploration noise added to
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target 
+        target_noise (float): Stddev for smoothing noise added to target
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy 
+        noise_clip (float): Limit for absolute value of target policy
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every 
+        policy_delay (int): Policy will only be updated once every
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -132,11 +133,11 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q1, q2, q1_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-    
+
     # Target policy network
     with tf.variable_scope('target'):
         pi_targ, _, _, _  = actor_critic(x2_ph, a_ph, **ac_kwargs)
-    
+
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -212,8 +213,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards, 
-        use the learned policy (with some noise, via act_noise). 
+        from a uniform distribution for better exploration. Afterwards,
+        use the learned policy (with some noise, via act_noise).
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -233,7 +234,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update 
+        # Super critical, easy to overlook step: make sure to update
         # most recent observation!
         o = o2
 
@@ -291,7 +292,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('--env', type=str, default='HalfCheetah-v2')
+    parser.add_argument('--env', type=str, default=HALFCHEETAH_ENV)
     parser.add_argument('--h', type=int, default=300)
     parser.add_argument('--l', type=int, default=1)
     parser.add_argument('--num_runs', '-n', type=int, default=3)
@@ -300,7 +301,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     def td3_with_actor_critic(**kwargs):
-        td3(ac_kwargs=dict(hidden_sizes=[args.h]*args.l), 
+        td3(ac_kwargs=dict(hidden_sizes=[args.h]*args.l),
             start_steps=5000,
             max_ep_len=150,
             batch_size=64,

--- a/spinup/exercises/problem_set_2/exercise2_3.py
+++ b/spinup/exercises/problem_set_2/exercise2_3.py
@@ -190,7 +190,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, outputs={'pi': pi, 'q1': q1, 'q2': q2})
 
     def get_action(o, noise_scale):
-        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})
+        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})[0]
         a += noise_scale * np.random.randn(act_dim)
         return np.clip(a, -act_limit, act_limit)
 

--- a/spinup/exercises/problem_set_2/exercise2_3.py
+++ b/spinup/exercises/problem_set_2/exercise2_3.py
@@ -9,24 +9,23 @@ from spinup.utils.logx import EpochLogger
 from spinup.utils.run_utils import ExperimentGrid
 from spinup.user_config import HALFCHEETAH_ENV
 
-
 """
 
 Exercise 2.3: Details Matter
 
 In this exercise, you will run TD3 with a tiny implementation difference,
-pertaining to how target actions are calculated. Your goal is to determine
+pertaining to how target actions are calculated. Your goal is to determine 
 whether or not there is any change in performance, and if so, explain why.
 
 You do NOT need to write code for this exercise.
 
 """
 
-def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
-        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99,
-        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000,
-        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2,
-        max_ep_len=1000, logger_kwargs=dict(), save_freq=1,
+def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0, 
+        steps_per_epoch=5000, epochs=100, replay_size=int(1e6), gamma=0.99, 
+        polyak=0.995, pi_lr=1e-3, q_lr=1e-3, batch_size=100, start_steps=10000, 
+        act_noise=0.1, target_noise=0.2, noise_clip=0.5, policy_delay=2, 
+        max_ep_len=1000, logger_kwargs=dict(), save_freq=1, 
         remove_action_clip=False):
     """
 
@@ -34,8 +33,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         env_fn : A function which creates a copy of the environment.
             The environment must satisfy the OpenAI Gym API.
 
-        actor_critic: A function which takes in placeholder symbols
-            for state, ``x_ph``, and action, ``a_ph``, and returns the main
+        actor_critic: A function which takes in placeholder symbols 
+            for state, ``x_ph``, and action, ``a_ph``, and returns the main 
             outputs from the agent's Tensorflow computation graph:
 
             ===========  ================  ======================================
@@ -43,23 +42,23 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             ===========  ================  ======================================
             ``pi``       (batch, act_dim)  | Deterministically computes actions
                                            | from policy given states.
-            ``q1``       (batch,)          | Gives one estimate of Q* for
+            ``q1``       (batch,)          | Gives one estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q2``       (batch,)          | Gives another estimate of Q* for
+            ``q2``       (batch,)          | Gives another estimate of Q* for 
                                            | states in ``x_ph`` and actions in
                                            | ``a_ph``.
-            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and
-                                           | ``pi`` for states in ``x_ph``:
+            ``q1_pi``    (batch,)          | Gives the composition of ``q1`` and 
+                                           | ``pi`` for states in ``x_ph``: 
                                            | q1(x, pi(x)).
             ===========  ================  ======================================
 
-        ac_kwargs (dict): Any kwargs appropriate for the actor_critic
+        ac_kwargs (dict): Any kwargs appropriate for the actor_critic 
             function you provided to TD3.
 
         seed (int): Seed for random number generators.
 
-        steps_per_epoch (int): Number of steps of interaction (state-action pairs)
+        steps_per_epoch (int): Number of steps of interaction (state-action pairs) 
             for the agent and the environment in each epoch.
 
         epochs (int): Number of epochs to run and train agent.
@@ -68,14 +67,14 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         gamma (float): Discount factor. (Always between 0 and 1.)
 
-        polyak (float): Interpolation factor in polyak averaging for target
-            networks. Target networks are updated towards main networks
+        polyak (float): Interpolation factor in polyak averaging for target 
+            networks. Target networks are updated towards main networks 
             according to:
 
-            .. math:: \\theta_{\\text{targ}} \\leftarrow
+            .. math:: \\theta_{\\text{targ}} \\leftarrow 
                 \\rho \\theta_{\\text{targ}} + (1-\\rho) \\theta
 
-            where :math:`\\rho` is polyak. (Always between 0 and 1, usually
+            where :math:`\\rho` is polyak. (Always between 0 and 1, usually 
             close to 1.)
 
         pi_lr (float): Learning rate for policy.
@@ -87,16 +86,16 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         start_steps (int): Number of steps for uniform-random action selection,
             before running real policy. Helps exploration.
 
-        act_noise (float): Stddev for Gaussian exploration noise added to
+        act_noise (float): Stddev for Gaussian exploration noise added to 
             policy at training time. (At test time, no noise is added.)
 
-        target_noise (float): Stddev for smoothing noise added to target
+        target_noise (float): Stddev for smoothing noise added to target 
             policy.
 
-        noise_clip (float): Limit for absolute value of target policy
+        noise_clip (float): Limit for absolute value of target policy 
             smoothing noise.
 
-        policy_delay (int): Policy will only be updated once every
+        policy_delay (int): Policy will only be updated once every 
             policy_delay times for each update of the Q-networks.
 
         max_ep_len (int): Maximum length of trajectory / episode / rollout.
@@ -133,11 +132,11 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     # Main outputs from computation graph
     with tf.variable_scope('main'):
         pi, q1, q2, q1_pi = actor_critic(x_ph, a_ph, **ac_kwargs)
-
+    
     # Target policy network
     with tf.variable_scope('target'):
         pi_targ, _, _, _  = actor_critic(x2_ph, a_ph, **ac_kwargs)
-
+    
     # Target Q networks
     with tf.variable_scope('target', reuse=True):
 
@@ -213,8 +212,8 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
         """
         Until start_steps have elapsed, randomly sample actions
-        from a uniform distribution for better exploration. Afterwards,
-        use the learned policy (with some noise, via act_noise).
+        from a uniform distribution for better exploration. Afterwards, 
+        use the learned policy (with some noise, via act_noise). 
         """
         if t > start_steps:
             a = get_action(o, act_noise)
@@ -234,7 +233,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         # Store experience to replay buffer
         replay_buffer.store(o, a, r, o2, d)
 
-        # Super critical, easy to overlook step: make sure to update
+        # Super critical, easy to overlook step: make sure to update 
         # most recent observation!
         o = o2
 
@@ -301,7 +300,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     def td3_with_actor_critic(**kwargs):
-        td3(ac_kwargs=dict(hidden_sizes=[args.h]*args.l),
+        td3(ac_kwargs=dict(hidden_sizes=[args.h]*args.l), 
             start_steps=5000,
             max_ep_len=150,
             batch_size=64,

--- a/spinup/run.py
+++ b/spinup/run.py
@@ -1,4 +1,5 @@
 import spinup
+from spinup.user_config import PYTHON_NAME
 from spinup.utils.run_utils import ExperimentGrid
 from spinup.utils.serialization_utils import convert_json
 import argparse
@@ -10,6 +11,7 @@ import string
 import tensorflow as tf
 from textwrap import dedent
 
+import pybullet_envs
 
 # Command line args that will go to ExperimentGrid.run, and must possess unique
 # values (therefore must be treated separately).
@@ -221,7 +223,7 @@ if __name__ == '__main__':
     elif cmd in valid_utils:
         # Execute the correct utility file.
         runfile = osp.join(osp.abspath(osp.dirname(__file__)), 'utils', cmd +'.py')
-        args = ['python', runfile] + sys.argv[2:]
+        args = [PYTHON_NAME, runfile] + sys.argv[2:]
         subprocess.check_call(args, env=os.environ)
     else:
         # Assume that the user plans to execute an algorithm. Run custom

--- a/spinup/user_config.py
+++ b/spinup/user_config.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import importlib
 import os.path as osp
 
 # Where experiment outputs are saved by default:
@@ -11,6 +13,18 @@ FORCE_DATESTAMP = False
 # Whether GridSearch provides automatically-generated default shorthands:
 DEFAULT_SHORTHAND = True
 
-# Tells the GridSearch how many seconds to pause for before launching 
+# Tells the GridSearch how many seconds to pause for before launching
 # experiments.
 WAIT_BEFORE_LAUNCH = 5
+
+PYTHON_NAME = 'python'
+if sys.version_info[0] == 3:
+    PYTHON_NAME = 'python3'
+
+HAS_MUJOCO = (importlib.find_loader('mujoco_py') != None)
+
+HALFCHEETAH_ENV = 'HalfCheetah-v2'
+INVERTEDPENDULUM_ENV = 'InvertedPendulum-v0'
+if not HAS_MUJOCO:
+    HALFCHEETAH_ENV = 'HalfCheetahBulletEnv-v0'
+    INVERTEDPENDULUM_ENV = 'InvertedPendulumBulletEnv-v0'

--- a/spinup/utils/logx.py
+++ b/spinup/utils/logx.py
@@ -43,7 +43,7 @@ def restore_tf_graph(sess, fpath):
     """
     Loads graphs saved by Logger.
 
-    Will output a dictionary whose keys and values are from the 'inputs'
+    Will output a dictionary whose keys and values are from the 'inputs' 
     and 'outputs' dict you specified with logger.setup_tf_saver().
 
     Args:
@@ -52,7 +52,7 @@ def restore_tf_graph(sess, fpath):
 
     Returns:
         A dictionary mapping from keys to tensors in the computation graph
-        loaded from ``fpath``.
+        loaded from ``fpath``. 
     """
     tf.saved_model.loader.load(
                 sess,
@@ -70,7 +70,7 @@ class Logger:
     """
     A general-purpose logger.
 
-    Makes it easy to save diagnostics, hyperparameter configurations, the
+    Makes it easy to save diagnostics, hyperparameter configurations, the 
     state of a training run, and the trained model.
     """
 
@@ -79,13 +79,13 @@ class Logger:
         Initialize a Logger.
 
         Args:
-            output_dir (string): A directory for saving results to. If
+            output_dir (string): A directory for saving results to. If 
                 ``None``, defaults to a temp directory of the form
                 ``/tmp/experiments/somerandomnumber``.
 
-            output_fname (string): Name for the tab-separated-value file
-                containing metrics logged throughout a training run.
-                Defaults to ``progress.txt``.
+            output_fname (string): Name for the tab-separated-value file 
+                containing metrics logged throughout a training run. 
+                Defaults to ``progress.txt``. 
 
             exp_name (string): Experiment name. If you run multiple training
                 runs and give them all the same ``exp_name``, the plotter
@@ -138,7 +138,7 @@ class Logger:
         Call this once at the top of your experiment, passing in all important
         config vars as a dict. This will serialize the config to JSON, while
         handling anything which can't be serialized in a graceful way (writing
-        as informative a string as possible).
+        as informative a string as possible). 
 
         Example use:
 
@@ -164,11 +164,11 @@ class Logger:
         To be clear: this is about saving *state*, not logging diagnostics.
         All diagnostic logging is separate from this function. This function
         will save whatever is in ``state_dict``---usually just a copy of the
-        environment---and the most recent parameters for the model you
-        previously set up saving for with ``setup_tf_saver``.
+        environment---and the most recent parameters for the model you 
+        previously set up saving for with ``setup_tf_saver``. 
 
         Call with any frequency you prefer. If you only want to maintain a
-        single state and overwrite it at each call with the most recent
+        single state and overwrite it at each call with the most recent 
         version, leave ``itr=None``. If you want to keep all of the states you
         save, provide unique (increasing) values for 'itr'.
 
@@ -204,7 +204,7 @@ class Logger:
                 graph.
 
             inputs (dict): A dictionary that maps from keys of your choice
-                to the tensorflow placeholders that serve as inputs to the
+                to the tensorflow placeholders that serve as inputs to the 
                 computation graph. Make sure that *all* of the placeholders
                 needed for your outputs are included!
 
@@ -218,7 +218,7 @@ class Logger:
     def _tf_simple_save(self, itr=None):
         """
         Uses simple_save to save a trained model, plus info to make it easy
-        to associated tensors to variables after restore.
+        to associated tensors to variables after restore. 
         """
         if proc_id()==0:
             assert hasattr(self, 'tf_saver_elements'), \
@@ -231,7 +231,7 @@ class Logger:
                 shutil.rmtree(fpath)
             tf.saved_model.simple_save(export_dir=fpath, **self.tf_saver_elements)
             joblib.dump(self.tf_saver_info, osp.join(fpath, 'model_info.pkl'))
-
+    
     def dump_tabular(self):
         """
         Write all of the diagnostics from the current iteration.
@@ -265,18 +265,18 @@ class EpochLogger(Logger):
     A variant of Logger tailored for tracking average values over epochs.
 
     Typical use case: there is some quantity which is calculated many times
-    throughout an epoch, and at the end of the epoch, you would like to
+    throughout an epoch, and at the end of the epoch, you would like to 
     report the average / std / min / max value of that quantity.
 
     With an EpochLogger, each time the quantity is calculated, you would
-    use
+    use 
 
     .. code-block:: python
 
         epoch_logger.store(NameOfQuantity=quantity_value)
 
-    to load it into the EpochLogger's state. Then at the end of the epoch, you
-    would use
+    to load it into the EpochLogger's state. Then at the end of the epoch, you 
+    would use 
 
     .. code-block:: python
 
@@ -293,7 +293,7 @@ class EpochLogger(Logger):
         """
         Save something into the epoch_logger's current state.
 
-        Provide an arbitrary number of keyword arguments with numerical
+        Provide an arbitrary number of keyword arguments with numerical 
         values.
         """
         for k,v in kwargs.items():
@@ -307,14 +307,14 @@ class EpochLogger(Logger):
 
         Args:
             key (string): The name of the diagnostic. If you are logging a
-                diagnostic whose state has previously been saved with
+                diagnostic whose state has previously been saved with 
                 ``store``, the key here has to match the key you used there.
 
             val: A value for the diagnostic. If you have previously saved
                 values for this key via ``store``, do *not* provide a ``val``
                 here.
 
-            with_min_and_max (bool): If true, log min and max values of the
+            with_min_and_max (bool): If true, log min and max values of the 
                 diagnostic over the epoch.
 
             average_only (bool): If true, do not log the standard deviation

--- a/spinup/utils/run_utils.py
+++ b/spinup/utils/run_utils.py
@@ -27,7 +27,7 @@ def setup_logger_kwargs(exp_name, seed=None, data_dir=None, datestamp=False):
     """
     Sets up the output_dir for a logger and returns a dict for logger kwargs.
 
-    If no seed is given and datestamp is false,
+    If no seed is given and datestamp is false, 
 
     ::
 
@@ -45,8 +45,8 @@ def setup_logger_kwargs(exp_name, seed=None, data_dir=None, datestamp=False):
 
         output_dir = data_dir/YY-MM-DD_exp_name/YY-MM-DD_HH-MM-SS_exp_name_s[seed]
 
-    You can force datestamp=True by setting ``FORCE_DATESTAMP=True`` in
-    ``spinup/user_config.py``.
+    You can force datestamp=True by setting ``FORCE_DATESTAMP=True`` in 
+    ``spinup/user_config.py``. 
 
     Args:
 
@@ -71,7 +71,7 @@ def setup_logger_kwargs(exp_name, seed=None, data_dir=None, datestamp=False):
     # Make base path
     ymd_time = time.strftime("%Y-%m-%d_") if datestamp else ''
     relpath = ''.join([ymd_time, exp_name])
-
+    
     if seed is not None:
         # Make a seed-specific subfolder in the experiment directory.
         if datestamp:
@@ -82,30 +82,30 @@ def setup_logger_kwargs(exp_name, seed=None, data_dir=None, datestamp=False):
         relpath = osp.join(relpath, subfolder)
 
     data_dir = data_dir or DEFAULT_DATA_DIR
-    logger_kwargs = dict(output_dir=osp.join(data_dir, relpath),
+    logger_kwargs = dict(output_dir=osp.join(data_dir, relpath), 
                          exp_name=exp_name)
     return logger_kwargs
 
 
-def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
+def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None, 
                     datestamp=False, **kwargs):
     """
     Run a function (thunk) with hyperparameters (kwargs), plus configuration.
 
     This wraps a few pieces of functionality which are useful when you want
     to run many experiments in sequence, including logger configuration and
-    splitting into multiple processes for MPI.
+    splitting into multiple processes for MPI. 
 
     There's also a SpinningUp-specific convenience added into executing the
     thunk: if ``env_name`` is one of the kwargs passed to call_experiment, it's
     assumed that the thunk accepts an argument called ``env_fn``, and that
-    the ``env_fn`` should make a gym environment with the given ``env_name``.
+    the ``env_fn`` should make a gym environment with the given ``env_name``. 
 
     The way the experiment is actually executed is slightly complicated: the
     function is serialized to a string, and then ``run_entrypoint.py`` is
     executed in a subprocess call with the serialized string as an argument.
     ``run_entrypoint.py`` unserializes the function call and executes it.
-    We choose to do it this way---instead of just calling the function
+    We choose to do it this way---instead of just calling the function 
     directly here---to avoid leaking state between successive experiments.
 
     Args:
@@ -122,7 +122,7 @@ def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
 
         data_dir (string): Used in configuring the logger, to decide where
             to store experiment results. Note: if left as None, data_dir will
-            default to ``DEFAULT_DATA_DIR`` from ``spinup/user_config.py``.
+            default to ``DEFAULT_DATA_DIR`` from ``spinup/user_config.py``. 
 
         **kwargs: All kwargs to pass to thunk.
 
@@ -176,9 +176,9 @@ def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
 
             There appears to have been an error in your experiment.
 
-            Check the traceback above to see what actually went wrong. The
+            Check the traceback above to see what actually went wrong. The 
             traceback below, included for completeness (but probably not useful
-            for diagnosing the error), shows the stack leading up to the
+            for diagnosing the error), shows the stack leading up to the 
             experiment launch.
 
             """) + '='*DIV_LINE_WIDTH + '\n'*3
@@ -188,7 +188,7 @@ def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
     # Tell the user about where results are, and how to check them
     logger_kwargs = kwargs['logger_kwargs']
 
-    plot_cmd = PYTHON_NAME + ' -m spinup.run plot ' + logger_kwargs['output_dir']
+    plot_cmd = PYTHON_NAME + '-m spinup.run plot '+logger_kwargs['output_dir']
     plot_cmd = colorize(plot_cmd, 'green')
 
     test_cmd = PYTHON_NAME + ' -m spinup.run test_policy '+logger_kwargs['output_dir']
@@ -217,7 +217,7 @@ def all_bools(vals):
     return all([isinstance(v,bool) for v in vals])
 
 def valid_str(v):
-    """
+    """ 
     Convert a value or values to a string which could go in a filepath.
 
     Partly based on `this gist`_.
@@ -232,7 +232,7 @@ def valid_str(v):
         return '-'.join([valid_str(x) for x in v])
 
     # Valid characters are '-', '_', and alphanumeric. Replace invalid chars
-    # with '-'.
+    # with '-'. 
     str_v = str(v).lower()
     valid_chars = "-_%s%s" % (string.ascii_letters, string.digits)
     str_v = ''.join(c if c in valid_chars else '-' for c in str_v)
@@ -295,7 +295,7 @@ class ExperimentGrid:
 
 
     def _default_shorthand(self, key):
-        # Create a default shorthand for the key, built from the first
+        # Create a default shorthand for the key, built from the first 
         # three letters of each colon-separated part.
         # But if the first three letters contains something which isn't
         # alphanumeric, shear that off.
@@ -312,16 +312,16 @@ class ExperimentGrid:
         By default, if a shorthand isn't given, one is automatically generated
         from the key using the first three letters of each colon-separated
         term. To disable this behavior, change ``DEFAULT_SHORTHAND`` in the
-        ``spinup/user_config.py`` file to ``False``.
+        ``spinup/user_config.py`` file to ``False``. 
 
         Args:
             key (string): Name of parameter.
 
             vals (value or list of values): Allowed values of parameter.
 
-            shorthand (string): Optional, shortened name of parameter. For
+            shorthand (string): Optional, shortened name of parameter. For 
                 example, maybe the parameter ``steps_per_epoch`` is shortened
-                to ``steps``.
+                to ``steps``. 
 
             in_name (bool): When constructing variant names, force the
                 inclusion of this parameter into the name.
@@ -342,8 +342,8 @@ class ExperimentGrid:
         """
         Given a variant (dict of valid param/value pairs), make an exp_name.
 
-        A variant's name is constructed as the grid name (if you've given it
-        one), plus param names (or shorthands if available) and values
+        A variant's name is constructed as the grid name (if you've given it 
+        one), plus param names (or shorthands if available) and values 
         separated by underscores.
 
         Note: if ``seed`` is a parameter, it is not included in the name.
@@ -351,7 +351,7 @@ class ExperimentGrid:
 
         def get_val(v, k):
             # Utility method for getting the correct value out of a variant
-            # given as a nested dict. Assumes that a parameter name, k,
+            # given as a nested dict. Assumes that a parameter name, k, 
             # describes a path into the nested dict, such that k='a:b:c'
             # corresponds to value=variant['a']['b']['c']. Uses recursion
             # to get this.
@@ -372,7 +372,7 @@ class ExperimentGrid:
             # Include a parameter in a name if either 1) it can take multiple
             # values, or 2) the user specified that it must appear in the name.
             # Except, however, when the parameter is 'seed'. Seed is handled
-            # differently so that runs of the same experiment, with different
+            # differently so that runs of the same experiment, with different 
             # seeds, will be grouped by experiment name.
             if (len(v)>1 or inn) and not(k=='seed'):
 
@@ -384,7 +384,7 @@ class ExperimentGrid:
                 variant_val = get_val(variant, k)
 
                 # Append to name
-                if all_bools(v):
+                if all_bools(v): 
                     # If this is a param which only takes boolean values,
                     # only include in the name if it's True for this variant.
                     var_name += ('_' + param_name) if variant_val else ''
@@ -440,13 +440,13 @@ class ExperimentGrid:
                         a : 1,
                         b : 2
                         }
-                    }
+                    }    
                 }
         """
         flat_variants = self._variants(self.keys, self.vals)
 
         def unflatten_var(var):
-            """
+            """ 
             Build the full nested dict version of var, based on key names.
             """
             new_var = dict()
@@ -484,11 +484,11 @@ class ExperimentGrid:
         Run each variant in the grid with function 'thunk'.
 
         Note: 'thunk' must be either a callable function, or a string. If it is
-        a string, it must be the name of a parameter whose values are all
+        a string, it must be the name of a parameter whose values are all 
         callable functions.
 
         Uses ``call_experiment`` to actually launch each experiment, and gives
-        each variant a name using ``self.variant_name()``.
+        each variant a name using ``self.variant_name()``. 
 
         Maintenance note: the args for ExperimentGrid.run should track closely
         to the args for call_experiment. However, ``seed`` is omitted because
@@ -505,7 +505,7 @@ class ExperimentGrid:
         var_names = set([self.variant_name(var) for var in variants])
         var_names = sorted(list(var_names))
         line = '='*DIV_LINE_WIDTH
-        preparing = colorize('Preparing to run the following experiments...',
+        preparing = colorize('Preparing to run the following experiments...', 
                              color='green', bold=True)
         joined_var_names = '\n'.join(var_names)
         announcement = f"\n{preparing}\n\n{joined_var_names}\n\n{line}"
@@ -522,8 +522,8 @@ class ExperimentGrid:
             """), color='cyan', bold=True)+line
             print(delay_msg)
             wait, steps = WAIT_BEFORE_LAUNCH, 100
-            prog_bar = trange(steps, desc='Launching in...',
-                              leave=False, ncols=DIV_LINE_WIDTH,
+            prog_bar = trange(steps, desc='Launching in...', 
+                              leave=False, ncols=DIV_LINE_WIDTH, 
                               mininterval=0.25,
                               bar_format='{desc}: {bar}| {remaining} {elapsed}')
             for _ in prog_bar:
@@ -536,7 +536,7 @@ class ExperimentGrid:
             # Figure out what the thunk is.
             if isinstance(thunk, str):
                 # Assume one of the variant parameters has the same
-                # name as the string you passed for thunk, and that
+                # name as the string you passed for thunk, and that 
                 # variant[thunk] is a valid callable function.
                 thunk_ = var[thunk]
                 del var[thunk]
@@ -544,7 +544,7 @@ class ExperimentGrid:
                 # Assume thunk is given as a function.
                 thunk_ = thunk
 
-            call_experiment(exp_name, thunk_, num_cpu=num_cpu,
+            call_experiment(exp_name, thunk_, num_cpu=num_cpu, 
                             data_dir=data_dir, datestamp=datestamp, **var)
 
 


### PR DESCRIPTION
I have updated algorithms and problem sets to run using pybullet environments. I also updated the run commands to use python3 explicitly if launched under python3 (which was an issue in my env). 

Notes:

- For three algos (ddpg, sac, td3), the action being sent to the env was a list of actions returned by the actor_critic model, eg [[0,0,0]]. pybullet requires just one action. I think mujoco accepts either, but it would be useful for someone with mujoco to check everything is still working properly.
- The pybullet env state is not serializable, but we can save the env ID and recreate the env with gym. This won't always make sense, but does allow policies to be tested straight from command line in the simple case.
