### PR TITLE
modified the test_agent function

### DIFF
--- a/spinup/algos/ddpg/ddpg.py
+++ b/spinup/algos/ddpg/ddpg.py
@@ -185,13 +185,13 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
     def test_agent(n=10):
         for j in range(n):
-            o, r, d, ep_ret, ep_len = test_env.reset(), 0, False, 0, 0
-            while not(d or (ep_len == max_ep_len)):
+            o_test, r_test, d_test, ep_ret_test, ep_len_test = test_env.reset(), 0, False, 0, 0
+            while not(d_test or (ep_len_test == max_ep_len)):
                 # Take deterministic actions at test time (noise_scale=0)
-                o, r, d, _ = test_env.step(get_action(o, 0))
-                ep_ret += r
-                ep_len += 1
-            logger.store(TestEpRet=ep_ret, TestEpLen=ep_len)
+                o_test, r_test, d_test, _ = test_env.step(get_action(o_test, 0))
+                ep_ret_test += r_test
+                ep_len_test += 1
+            logger.store(TestEpRet=ep_ret_test, TestEpLen=ep_len_test)
 
     start_time = time.time()
     o, r, d, ep_ret, ep_len = env.reset(), 0, False, 0, 0

--- a/spinup/algos/sac/sac.py
+++ b/spinup/algos/sac/sac.py
@@ -220,13 +220,13 @@ def sac(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     def test_agent(n=10):
         global sess, mu, pi, q1, q2, q1_pi, q2_pi
         for j in range(n):
-            o, r, d, ep_ret, ep_len = test_env.reset(), 0, False, 0, 0
-            while not(d or (ep_len == max_ep_len)):
+            o_test, r_test, d_test, ep_ret_test, ep_len_test = test_env.reset(), 0, False, 0, 0
+            while not(d_test or (ep_len_test == max_ep_len)):
                 # Take deterministic actions at test time 
-                o, r, d, _ = test_env.step(get_action(o, True))
-                ep_ret += r
-                ep_len += 1
-            logger.store(TestEpRet=ep_ret, TestEpLen=ep_len)
+                o_test, r_test, d_test, _ = test_env.step(get_action(o_test, True))
+                ep_ret_test += r_test
+                ep_len_test += 1
+            logger.store(TestEpRet=ep_ret_test, TestEpLen=ep_len_test)
 
     start_time = time.time()
     o, r, d, ep_ret, ep_len = env.reset(), 0, False, 0, 0

--- a/spinup/algos/td3/td3.py
+++ b/spinup/algos/td3/td3.py
@@ -211,13 +211,13 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
     def test_agent(n=10):
         for j in range(n):
-            o, r, d, ep_ret, ep_len = test_env.reset(), 0, False, 0, 0
-            while not(d or (ep_len == max_ep_len)):
+            o_test, r_test, d_test, ep_ret_test, ep_len_test = test_env.reset(), 0, False, 0, 0
+            while not(d_test or (ep_len_test == max_ep_len)):
                 # Take deterministic actions at test time (noise_scale=0)
-                o, r, d, _ = test_env.step(get_action(o, 0))
-                ep_ret += r
-                ep_len += 1
-            logger.store(TestEpRet=ep_ret, TestEpLen=ep_len)
+                o_test, r_test, d_test, _ = test_env.step(get_action(o_test, 0))
+                ep_ret_test += r_test
+                ep_len_test += 1
+            logger.store(TestEpRet=ep_ret_test, TestEpLen=ep_len_test)
 
     start_time = time.time()
     o, r, d, ep_ret, ep_len = env.reset(), 0, False, 0, 0


### PR DESCRIPTION
If we do not modify the variable name in the test_agnet function, the last observation we got from the test env might be used for the training process. Similarly, ep_len and ep_ret will also go wrong.