### PR TITLE
Use current python interpreter in subprocesses

### DIFF
--- a/spinup/run.py
+++ b/spinup/run.py
@@ -221,7 +221,7 @@ if __name__ == '__main__':
     elif cmd in valid_utils:
         # Execute the correct utility file.
         runfile = osp.join(osp.abspath(osp.dirname(__file__)), 'utils', cmd +'.py')
-        args = ['python', runfile] + sys.argv[2:]
+        args = [sys.executable if sys.executable else 'python', runfile] + sys.argv[2:]
         subprocess.check_call(args, env=os.environ)
     else:
         # Assume that the user plans to execute an algorithm. Run custom

--- a/spinup/utils/run_utils.py
+++ b/spinup/utils/run_utils.py
@@ -166,7 +166,7 @@ def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
     encoded_thunk = base64.b64encode(zlib.compress(pickled_thunk)).decode('utf-8')
 
     entrypoint = osp.join(osp.abspath(osp.dirname(__file__)),'run_entrypoint.py')
-    cmd = ['python', entrypoint, encoded_thunk]
+    cmd = [sys.executable, entrypoint, encoded_thunk]
     try:
         subprocess.check_call(cmd, env=os.environ)
     except CalledProcessError:

--- a/spinup/utils/run_utils.py
+++ b/spinup/utils/run_utils.py
@@ -166,7 +166,7 @@ def call_experiment(exp_name, thunk, seed=0, num_cpu=1, data_dir=None,
     encoded_thunk = base64.b64encode(zlib.compress(pickled_thunk)).decode('utf-8')
 
     entrypoint = osp.join(osp.abspath(osp.dirname(__file__)),'run_entrypoint.py')
-    cmd = [sys.executable, entrypoint, encoded_thunk]
+    cmd = [sys.executable if sys.executable else 'python', entrypoint, encoded_thunk]
     try:
         subprocess.check_call(cmd, env=os.environ)
     except CalledProcessError:

--- a/spinup/version.py
+++ b/spinup/version.py
@@ -1,4 +1,4 @@
-version_info = (0, 1, 1)
+version_info = (0, 1, 2)
 # format:
 # ('spinup_major', 'spinup_minor', 'spinup_patch')
 


### PR DESCRIPTION
Use sys.executable to get and use the python interpreter of the current process in subprocesses, rather than whatever is currently linked to the 'python' command in the base environment. 

Fixed the case of me only having installed mujuco_py in my conda spinningup virtual env, breaking when using ExperimentGrid with a mujuco env, and should fix #13 and fix #34 where the subprocesses were run in python 2 despite running spinup/run.py in python 3.

Reverts to using 'python' in the following case from the [docs](https://docs.python.org/3/library/sys.html): "If Python is unable to retrieve the real path to its executable, sys.executable will be an empty string or None".