### PR TITLE
Clarify Anaconda version used

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -27,7 +27,7 @@ Installing Python
 
 We recommend installing Python through Anaconda. Anaconda is a library that includes Python and many useful packages for Python, as well as an environment manager called conda that makes package management simple.
 
-Follow `the installation instructions`_ for Anaconda here. Download and install Anaconda 3.x (at time of writing, 3.6). Then create a conda env for organizing packages used in Spinning Up:
+Follow `the installation instructions`_ for Anaconda here. Download and install Anaconda3 (at time of writing, `Anaconda3-5.3.0`_). Then create a conda Python 3.6 env for organizing packages used in Spinning Up:
 
 .. parsed-literal::
 
@@ -51,6 +51,7 @@ To use Python from the environment you just created, activate the environment wi
 
 
 .. _`the installation instructions`: https://docs.continuum.io/anaconda/install/
+.. _`Anaconda3-5.3.0`: https://repo.anaconda.com/archive/
 .. _`FreeCodeCamp`: https://medium.freecodecamp.org/why-you-need-python-environments-and-how-to-manage-them-with-conda-85f155f4353c
 .. _`Towards Data Science`: https://towardsdatascience.com/environment-management-with-conda-python-2-3-b9961a8a5097
 .. _`documentation page from Conda`: https://conda.io/docs/user-guide/tasks/manage-environments.html


### PR DESCRIPTION
This part of documentation was a bit confusing to me. I wanted to download exact version of Anaconda you used to avoid versioning hell, but then I couldn't find Anaconda 3.6. After realising that Anaconda3* covers all Python 3.* versions and that there is no Anaconda 3.6 I've inferred that version used when you've released Spinning Up (2018-11-08) was Anaconda3-5.3.0 because Anaconda3-5.3.1 was released on 2018-11-19.

I also wanted to reference the exact version used during the launch and point users to link where they can download previous versions of Anaconda as it can't be quickly found on Anaconda web page.

p.s. I haven't touched MuJoCo license link. It's probably EOF or some other formatting character that caused invisible change.