### PR TITLE
Fix "Legend.draggable() is deprecated" warning

### DIFF
--- a/spinup/utils/plot.py
+++ b/spinup/utils/plot.py
@@ -39,7 +39,7 @@ def plot_data(data, xaxis='Epoch', value="AverageEpRet", condition="Condition1",
 
     Changes the colorscheme and the default legend style, though.
     """
-    plt.legend(loc='best').draggable()
+    plt.legend(loc='best').set_draggable(True)
 
     """
     For the version of the legend used in the Spinning Up benchmarking page, 


### PR DESCRIPTION
Just a small fix for a deprecated warning.

Before:
<pre>$ python -m spinup.run plot data/installtest/installtest_s0 -s3
Plotting from...
==================================================

data/installtest/installtest_s0

==================================================
/anaconda3/envs/spinningup/lib/python3.6/site-packages/seaborn/timeseries.py:183: UserWarning: The tsplot function is deprecated and will be removed or replaced (in a substantially altered version) in a future release.
  warnings.warn(msg, UserWarning)
/anaconda3/envs/spinningup/lib/python3.6/site-packages/matplotlib/legend.py:1196: MatplotlibDeprecationWarning: 
Legend.draggable() is drepecated in favor of Legend.set_draggable(). Legend.draggable may be reintroduced as a property in future releases.
  message="Legend.draggable() is drepecated in "
</pre>

After:
<pre>$ python -m spinup.run plot data/installtest/installtest_s0 -s3
Plotting from...
==================================================

data/installtest/installtest_s0

==================================================
/anaconda3/envs/spinningup/lib/python3.6/site-packages/seaborn/timeseries.py:183: UserWarning: The tsplot function is deprecated and will be removed or replaced (in a substantially altered version) in a future release.
  warnings.warn(msg, UserWarning)
</pre>