### PR TITLE
Issue in ddpg target policy update

### DIFF
--- a/spinup/algos/ddpg/ddpg.py
+++ b/spinup/algos/ddpg/ddpg.py
@@ -246,7 +246,8 @@ def ddpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
                 logger.store(LossQ=outs[0], QVals=outs[1])
 
                 # Policy update
-                outs = sess.run([pi_loss, train_pi_op, target_update], feed_dict)
+                outs = sess.run([pi_loss, train_pi_op], feed_dict)
+                sess.run([target_update])
                 logger.store(LossPi=outs[0])
 
             logger.store(EpRet=ep_ret, EpLen=ep_len)


### PR DESCRIPTION
Hello, 

In ddpg.py, line 249:
Please compute [pi_loss, train_pi_op] and [target_update] in separate runs (or enforce a control dependancy) since you are not controlling which one is called first. Actually, it occured in my experiments that target policy update is done before policy training; which is an unexpected behaviour. For instance at step 1, because parameters are initially synchronized, the target policy is not updated. At step 2, it will, but with shifted main parameters and so on.  

Practically, (and quiet surprisingly) you keep convergence and I guess this is because the bias propagation is limited through target policy. But technically it's not equivalent to the ddpg algorithm described here: https://spinningup.openai.com/en/latest/algorithms/ddpg.html since parameters of policy network and main network have mutual influence across iterations and the shift would be difficult to track.

Let me know,
Mathias