### PR TITLE
arguments -> section

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -89,7 +89,7 @@ Installing Spinning Up
 
 .. admonition:: You Should Know
 
-    Spinning Up defaults to installing everything in Gym **except** the MuJoCo environments. In case you run into any trouble with the Gym installation, check out the `Gym`_ github page for help. If you want the MuJoCo environments, see the optional installation arguments below.
+    Spinning Up defaults to installing everything in Gym **except** the MuJoCo environments. In case you run into any trouble with the Gym installation, check out the `Gym`_ github page for help. If you want the MuJoCo environments, see the optional installation section below.
 
 .. _`Gym`: https://github.com/openai/gym
 


### PR DESCRIPTION
When I read "optional installation arguments", I scanned below for a list of optional arguments to a command. I think "section" reads clearer here as this sentence refer to entire section below.