### PR TITLE
VPG reward shift

### DIFF
--- a/spinup/algos/vpg/vpg.py
+++ b/spinup/algos/vpg/vpg.py
@@ -233,11 +233,15 @@ def vpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         for t in range(local_steps_per_epoch):
             a, v_t, logp_t = sess.run(get_action_ops, feed_dict={x_ph: o.reshape(1,-1)})
 
+            # play step on environment
+            step_result = env.step(a[0])
+
             # save and log
-            buf.store(o, a, r, v_t, logp_t)
+            buf.store(o, a, step_result[1], v_t, logp_t)
             logger.store(VVals=v_t)
 
-            o, r, d, _ = env.step(a[0])
+            # unpack the step result
+            o, r, d, _ = step_result
             ep_ret += r
             ep_len += 1
 


### PR DESCRIPTION
Related to https://github.com/openai/spinningup/issues/67

This simple fix works well for me, but I'm not confident about VPGBuffer.finish_path which seems to append the last reward again. 
`rews = np.append(self.rew_buf[path_slice], last_val)`
This make rews longer than the previous slice and the rest of the buffers related to same trajectory.
Is that intended? Why ?

Does the slice below throw away the extra element ?
`self.ret_buf[path_slice] = core.discount_cumsum(rews, self.gamma)[:-1]`