### PR TITLE
Fix docs mistake for variants

### DIFF
--- a/spinup/utils/run_utils.py
+++ b/spinup/utils/run_utils.py
@@ -424,8 +424,8 @@ class ExperimentGrid:
             ====================  ===
             Key                   Val
             ====================  ===
-            ``'base:param:one'``  1
-            ``'base:param:two'``  2
+            ``'base:param:a'``    1
+            ``'base:param:b'``    2
             ====================  ===
 
         the variant dict will have the structure


### PR DESCRIPTION
The key/val table now matches the variant dict displayed below as 

```
 variant = {
    base: {
         param : {
             a : 1,
             b : 2
        }
    }    
}
```