### PR TITLE
Fix reward shift for policy gradient algorithms

### DIFF
--- a/spinup/algos/ppo/ppo.py
+++ b/spinup/algos/ppo/ppo.py
@@ -255,11 +255,14 @@ def ppo(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         for t in range(local_steps_per_epoch):
             a, v_t, logp_t = sess.run(get_action_ops, feed_dict={x_ph: o.reshape(1,-1)})
 
-            # save and log
+            o2, r, d, _ = env.step(a[0])
+
+            # save and log old_observation, new_action, new_reward, state_value, logp_action
             buf.store(o, a, r, v_t, logp_t)
             logger.store(VVals=v_t)
 
-            o, r, d, _ = env.step(a[0])
+            o = o2
+
             ep_ret += r
             ep_len += 1
 

--- a/spinup/algos/trpo/trpo.py
+++ b/spinup/algos/trpo/trpo.py
@@ -334,11 +334,14 @@ def trpo(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
             agent_outs = sess.run(get_action_ops, feed_dict={x_ph: o.reshape(1,-1)})
             a, v_t, logp_t, info_t = agent_outs[0][0], agent_outs[1], agent_outs[2], agent_outs[3:]
 
-            # save and log
+            o2, r, d, _ = env.step(a)
+
+            # save and log old_observation, new_action, new_reward, state_value, logp_action, info
             buf.store(o, a, r, v_t, logp_t, info_t)
             logger.store(VVals=v_t)
 
-            o, r, d, _ = env.step(a)
+            o = o2
+
             ep_ret += r
             ep_len += 1
 

--- a/spinup/algos/vpg/vpg.py
+++ b/spinup/algos/vpg/vpg.py
@@ -233,11 +233,14 @@ def vpg(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
         for t in range(local_steps_per_epoch):
             a, v_t, logp_t = sess.run(get_action_ops, feed_dict={x_ph: o.reshape(1,-1)})
 
-            # save and log
+            o2, r, d, _ = env.step(a[0])
+
+            # save and log old_observation, new_action, new_reward, state_value, logp_action
             buf.store(o, a, r, v_t, logp_t)
             logger.store(VVals=v_t)
 
-            o, r, d, _ = env.step(a[0])
+            o = o2
+
             ep_ret += r
             ep_len += 1
 


### PR DESCRIPTION
Addresses Issue #50 and Issue #67. Reward was being delayed for one time step when collecting experience. I noticed big improvements in PPO preformance on FrozenLake environment with this change. Any environment which rewards at the last end step is broken by this bug, but otherwise performance doesn't seem to be affected.