### PR TITLE
Fix exercise 1.3

### DIFF
--- a/spinup/exercises/problem_set_1/exercise1_3.py
+++ b/spinup/exercises/problem_set_1/exercise1_3.py
@@ -258,7 +258,7 @@ def td3(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
     logger.setup_tf_saver(sess, inputs={'x': x_ph, 'a': a_ph}, outputs={'pi': pi, 'q1': q1, 'q2': q2})
 
     def get_action(o, noise_scale):
-        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})
+        a = sess.run(pi, feed_dict={x_ph: o.reshape(1,-1)})[0]
         a += noise_scale * np.random.randn(act_dim)
         return np.clip(a, -act_limit, act_limit)
 


### PR DESCRIPTION
Actions are interpreted as scalars. In NumPy this is represented as an array, but with one of its dimensions size 0. Here, we desire a vector with the shape `(act_dim, )`. In the `get_action()` method, the action is assigned to the result of `sess.run(pi ...)` which returns an vector with shape `(act_dim, 1)`. We add the `[0]` here to remove the second dimension so it can be used properly. Without it, we can get an error, like the following:

```
> python exercise1_3.py --env RoboschoolHalfCheetah-v1
...
  File "/home/anaconda3/envs/spinningup/lib/python3.6/site-packages/roboschool/gym_forward_walker.py", line 43, in apply_action
    j.set_motor_torque( self.power*j.power_coef*float(np.clip(a[n], -1, +1)) )
TypeError: only size-1 arrays can be converted to Python scalars
```