### PR TITLE
fix GDrive link of Sutton & Barto

### DIFF
--- a/docs/_build/html/_sources/spinningup/rl_intro2.rst.txt
+++ b/docs/_build/html/_sources/spinningup/rl_intro2.rst.txt
@@ -83,7 +83,7 @@ Examples of Q-learning methods include
 .. _`Bellman equation`: ../spinningup/rl_intro.html#bellman-equations
 .. _`Tsitsiklis and van Roy`: http://web.mit.edu/jnt/www/Papers/J063-97-bvr-td.pdf
 .. _`review by Szepesvari`: https://sites.ualberta.ca/~szepesva/papers/RLAlgsInMDPs.pdf
-.. _`Sutton and Barto`: https://drive.google.com/file/d/1xeUDVGWGUUv1-ccUMAZHJLej2C7aAFWY/view
+.. _`Sutton and Barto`: https://drive.google.com/file/d/1opPSz5AZ_kVa1uWOdOiveNiBFiEOHjkG/view
 .. _`equivalent`: https://arxiv.org/abs/1704.06440
 
 What to Learn in Model-Based RL

--- a/docs/_build/html/spinningup/rl_intro2.html
+++ b/docs/_build/html/spinningup/rl_intro2.html
@@ -268,7 +268,7 @@
 <table class="docutils footnote" frame="void" id="id2" rules="none">
 <colgroup><col class="label" /><col /></colgroup>
 <tbody valign="top">
-<tr><td class="label"><a class="fn-backref" href="#id1">[1]</a></td><td>For more information about how and why Q-learning methods can fail, see 1) this classic paper by <a class="reference external" href="http://web.mit.edu/jnt/www/Papers/J063-97-bvr-td.pdf">Tsitsiklis and van Roy</a>, 2) the (much more recent) <a class="reference external" href="https://sites.ualberta.ca/~szepesva/papers/RLAlgsInMDPs.pdf">review by Szepesvari</a> (in section 4.3.2), and 3) chapter 11 of <a class="reference external" href="https://drive.google.com/file/d/1xeUDVGWGUUv1-ccUMAZHJLej2C7aAFWY/view">Sutton and Barto</a>, especially section 11.3 (on &#8220;the deadly triad&#8221; of function approximation, bootstrapping, and off-policy data, together causing instability in value-learning algorithms).</td></tr>
+<tr><td class="label"><a class="fn-backref" href="#id1">[1]</a></td><td>For more information about how and why Q-learning methods can fail, see 1) this classic paper by <a class="reference external" href="http://web.mit.edu/jnt/www/Papers/J063-97-bvr-td.pdf">Tsitsiklis and van Roy</a>, 2) the (much more recent) <a class="reference external" href="https://sites.ualberta.ca/~szepesva/papers/RLAlgsInMDPs.pdf">review by Szepesvari</a> (in section 4.3.2), and 3) chapter 11 of <a class="reference external" href="https://drive.google.com/file/d/1opPSz5AZ_kVa1uWOdOiveNiBFiEOHjkG/view">Sutton and Barto</a>, especially section 11.3 (on &#8220;the deadly triad&#8221; of function approximation, bootstrapping, and off-policy data, together causing instability in value-learning algorithms).</td></tr>
 </tbody>
 </table>
 </div>

--- a/docs/spinningup/rl_intro2.rst
+++ b/docs/spinningup/rl_intro2.rst
@@ -83,7 +83,7 @@ Examples of Q-learning methods include
 .. _`Bellman equation`: ../spinningup/rl_intro.html#bellman-equations
 .. _`Tsitsiklis and van Roy`: http://web.mit.edu/jnt/www/Papers/J063-97-bvr-td.pdf
 .. _`review by Szepesvari`: https://sites.ualberta.ca/~szepesva/papers/RLAlgsInMDPs.pdf
-.. _`Sutton and Barto`: https://drive.google.com/file/d/1xeUDVGWGUUv1-ccUMAZHJLej2C7aAFWY/view
+.. _`Sutton and Barto`: https://drive.google.com/file/d/1opPSz5AZ_kVa1uWOdOiveNiBFiEOHjkG/view
 .. _`equivalent`: https://arxiv.org/abs/1704.06440
 
 What to Learn in Model-Based RL


### PR DESCRIPTION
Thanks for creating great material for studying RL like this!

Since the previous Google Drive link for Sutton & Barto has been expired, I fixed it. However, the previous link still exists in `spinningup/docs/_build/doctrees/spinningup/rl_intro2.doctree` as binary format. Should I fix it, too?