### PR TITLE
Move MuJoCo to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'joblib',
         'matplotlib==3.0.2',
         'mpi4py',
-        'mujoco-py<2.1,>=2.0',
         'numpy',
         'pandas',
         'pytest',
@@ -30,6 +29,7 @@ setup(
         'tensorflow>=1.8.0,<2.0',
         'tqdm'
     ],
+    extras_require={'mujoco': 'mujoco-py<2.1,>=2.0'},
     description="Teaching tools for introducing people to deep RL.",
     author="Joshua Achiam",
 )


### PR DESCRIPTION
Making MuJoCo optional install, as putting it in install_requires results in error for people who do not want MuJoCo
To install MuJoCo as well ,  use  '**pip install -e .[mujoco]**'
'pip install -e .'  installs rest execpt mujoco