### PR TITLE
TRPO: correct the params positions of diagonal gaussian kl function.

### DIFF
--- a/spinup/algos/trpo/core.py
+++ b/spinup/algos/trpo/core.py
@@ -133,7 +133,7 @@ def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, actio
     logp_pi = gaussian_likelihood(pi, mu, log_std)
 
     old_mu_ph, old_log_std_ph = placeholders(act_dim, act_dim)
-    d_kl = diagonal_gaussian_kl(mu, log_std, old_mu_ph, old_log_std_ph)
+    d_kl = diagonal_gaussian_kl(old_mu_ph, old_log_std_ph, mu, log_std)
 
     info = {'mu': mu, 'log_std': log_std}
     info_phs = {'mu': old_mu_ph, 'log_std': old_log_std_ph}


### PR DESCRIPTION
## Background

The KL divergence (Kullback–Leibler divergence) is a measure of how one probability distribution is different from a second.

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/756dd25036c5da76a59e58a001f3196e059f537d)
And the KL divergence is asymmetric, which means

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/53dba8130c7f29ca4b04949b74139499467d5eb3)
To convey the fundamental asymmetry of the KL divergence, ![](https://wikimedia.org/api/rest_v1/media/math/render/svg/5c950157b274aa446fadb45e523a48c319e4b9fe) is described as the divergence of P from Q or the divergence from Q to P.


## Spinup code
The `diagonal_gaussian_kl` function implemented in spinup, calculates the KL divergence  from N1 to N0:

```python3
# spinningup/spinup/algos/trpo/core.py

def diagonal_gaussian_kl(mu0, log_std0, mu1, log_std1):
    """
    tf symbol for mean KL divergence between two batches of diagonal gaussian distributions,
    where distributions are specified by means and log stds.
    (https://en.wikipedia.org/wiki/Kullback-Leibler_divergence#Multivariate_normal_distributions)
    """
    var0, var1 = tf.exp(2 * log_std0), tf.exp(2 * log_std1)
    pre_sum = 0.5*(((mu1- mu0)**2 + var0)/(var1 + EPS) - 1) +  log_std1 - log_std0
    all_kls = tf.reduce_sum(pre_sum, axis=1)
    return tf.reduce_mean(all_kls)
```
which equals to:
![](https://wikimedia.org/api/rest_v1/media/math/render/svg/ccec30a0eb27534d7c859ec72a2b07a14ec0d965)
Why I use the term ***from N1 to N0*** here is because of the fundamental asymmetry of KL divergence, which means
![](https://wikimedia.org/api/rest_v1/media/math/render/svg/f27aa76ba168861a4ee605158dabaf5d49965142)

When invoking the `diagonal_gaussian_kl` function at the `mlp_gaussian_policy` function,
```python3
# spinningup/spinup/algos/trpo/core.py

def mlp_gaussian_policy(x, a, hidden_sizes, activation, output_activation, action_space):
    ...
    d_kl = diagonal_gaussian_kl(mu, log_std, old_mu_ph, old_log_std_ph)
    ...
```
the first two params represent the new policy and the last two params represent the old policy.
So the `d_kl` is the symbol of KL divergence ***from old policy to new policy***, which means:

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/3a7c9066fa47bee1287b2676b245f19ab34bfa2e)

## Problem

In the original TRPO paper, the trust region constraint is defined as:

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/6290fee6d6034b4bcb5c0c8afac906481d77d3aa)

where ![](https://wikimedia.org/api/rest_v1/media/math/render/svg/3a44f226bd531ef57ec3ccb12a786bc6addc8b1a) represents the KL divergence ***from new policy to old policy***. But in the code, the `d_kl` symbol calculates the KL divergence ***from old policy to new policy***, which is incorrect.
So the params to invoke the `diagonal_gaussian_kl` function is in a wrong order, we need correct it. 
Another equation in the original TRPO paper also confirms me in that the param order is wrong:

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/9ce2dc84870f9b894d093d65e4157ff8af83398a)

## Bug fix 
There are two options to fix this bug:
1. Change the param order when invoking the `diagonal_gaussian_kl` function:
We can replace  
`d_kl = diagonal_gaussian_kl(mu, log_std, old_mu_ph, old_log_std_ph)` 
with 
`d_kl = diagonal_gaussian_kl(old_mu_ph, old_log_std_ph, mu, log_std)`.

2. Keep the param order not changed, change the inside logic of `diagonal_gaussian_kl` function:
We can change the implementation of `diagonal_gaussian_kl` to get the correct KL divergence.
The new `diagonal_gaussian_kl` function is:
```python3
# spinningup/spinup/algos/trpo/core.py

def diagonal_gaussian_kl(mu0, log_std0, mu1, log_std1):
    """
    tf symbol for mean KL divergence between two batches of diagonal gaussian distributions,
    where distributions are specified by means and log stds.
    (https://en.wikipedia.org/wiki/Kullback-Leibler_divergence#Multivariate_normal_distributions)
    """
    var0, var1 = tf.exp(2 * log_std0), tf.exp(2 * log_std1)
    pre_sum = 0.5*(((mu0- mu1)**2 + var1)/(var0 + EPS) - 1) +  log_std0 - log_std1
    all_kls = tf.reduce_sum(pre_sum, axis=1)
    return tf.reduce_mean(all_kls)
```
which equals to:

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/b0bae4ec12a70a3031d7c08904d62b4d2656247f)
When invoking it with `d_kl = diagonal_gaussian_kl(mu, log_std, old_mu_ph, old_log_std_ph)`, the `d_kl` is the symbol of KL divergence ***from new policy to old policy***:

![](https://wikimedia.org/api/rest_v1/media/math/render/svg/2b237ee699a8e21945b45516034d111cd31afcc5)


The first option is simple, so I take it. 

## Reference 
- [Kullback-Leibler divergence ](https://en.wikipedia.org/w/index.php?title=Kullback%E2%80%93Leibler_divergence#Examples)
- [Trust Region Policy Optimization](https://arxiv.org/abs/1502.05477)

