### PR TITLE
Update example command to use existing environment

### DIFF
--- a/docs/user/running.rst
+++ b/docs/user/running.rst
@@ -26,6 +26,17 @@ eg:
 
     python -m spinup.run ppo --env Walker2d-v2 --exp_name walker
 
+.. admonition:: Important!
+    
+    If you do not have the MuJoCo package installed, you won't be able to run the Walker2d-cv2 environment, in this case use LunarLanderv2 instead
+    
+    e.g
+    
+.. parsed-literal::
+    
+        python -m spinup.run ppo --env LunarLander-v2 --exp_name lunar
+
+
 .. _`experiment outputs`: ../user/saving_and_loading.html
 .. _`plotting`: ../user/plotting.html
 


### PR DESCRIPTION
Changed example command to use free to use environment LunarLander-v2 instead of the Walker2d-v2 MuJoCo environment. This is to avoid confusion when new users who have not installed MuJoCo attempt to run this only to run into an error and become confused.