### PR TITLE
Add DQN(λ) paper to Deep Q-Learning section

### DIFF
--- a/docs/spinningup/keypapers.rst
+++ b/docs/spinningup/keypapers.rst
@@ -27,6 +27,8 @@ a. Deep Q-Learning
 
 .. [#] `Rainbow: Combining Improvements in Deep Reinforcement Learning <https://arxiv.org/abs/1710.02298>`_, Hessel et al, 2017. **Algorithm: Rainbow DQN.**
 
+.. [#] `Reconciling λ-Returns with Experience Replay <https://arxiv.org/abs/1810.09967>`_, Daley and Amato, 2019. **Algorithm: DQN(λ).**
+
 
 b. Policy Gradients
 -------------------


### PR DESCRIPTION
I recently published a paper at NeurIPS titled [_Reconciling λ-Returns with Experience Replay_](https://arxiv.org/abs/1810.09967) that I think will be interesting to the Spinning Up community. It describes a new algorithm, DQN(λ), that efficiently utilizes the more sophisticated credit-assignment properties of λ-returns instead of the typical _1_-step or _n_-step Bellman update. My hope is that including the paper in this list will help inspire new research ideas for sample-efficient deep RL.

Theoretically, our method can be combined with other replay algorithms like DDPG, but our experiments focused on DQN -- hence, it seems to make the most sense to include it in the Deep Q-Network section.