### PR TITLE
env.close() in test_policy

### DIFF
--- a/spinup/utils/test_policy.py
+++ b/spinup/utils/test_policy.py
@@ -101,7 +101,7 @@ def load_pytorch_policy(fpath, itr, deterministic=False):
     def get_action(x):
         with torch.no_grad():
             x = torch.as_tensor(x, dtype=torch.float32)
-            action = model.act(x)
+            action = model.act(x) if not deterministic else model.act(x, True)
         return action
 
     return get_action

--- a/spinup/utils/test_policy.py
+++ b/spinup/utils/test_policy.py
@@ -151,3 +151,4 @@ if __name__ == '__main__':
                                           args.itr if args.itr >=0 else 'last',
                                           args.deterministic)
     run_policy(env, get_action, args.len, args.episodes, not(args.norender))
+    env.close()


### PR DESCRIPTION
A minor fix for `spinup/utils/test_policy.py`. `env.close()` at the end to ensure proper closing of `gym.env`, or it may throw:
```
Exception ignored in: <function Viewer.__del__ at 0x1223aa440>
ImportError: sys.meta_path is None, Python is likely shutting down
```