### PR TITLE
docs update installation.rst 

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -61,7 +61,7 @@ Ubuntu
 
 .. parsed-literal::
 
-    sudo apt-get update && sudo apt-get install libopenmpi-dev
+    sudo apt-get update && sudo apt-get install libopenmpi-dev python3-dev
 
 
 Mac OS X


### PR DESCRIPTION
Installing mpi4py on Ubuntu also requires the python development headers (i.e, python3-dev).  This is not very clear from the errors you get, so it's worth including it in the instructions.