### PR TITLE
Fix Q-networks freezing in PyTorch SAC

### DIFF
--- a/spinup/algos/pytorch/sac/sac.py
+++ b/spinup/algos/pytorch/sac/sac.py
@@ -166,7 +166,7 @@ def sac(env_fn, actor_critic=core.MLPActorCritic, ac_kwargs=dict(), seed=0,
         p.requires_grad = False
         
     # List of parameters for both Q-networks (save this for convenience)
-    q_params = itertools.chain(ac.q1.parameters(), ac.q2.parameters())
+    q_params = list(itertools.chain(ac.q1.parameters(), ac.q2.parameters()))
 
     # Experience buffer
     replay_buffer = ReplayBuffer(obs_dim=obs_dim, act_dim=act_dim, size=replay_size)


### PR DESCRIPTION
The Q-network parameters were stored as an iterator rather than a list.
After the initial iteration for constructing the optimizer, the iterator would
be at the end. Store the parameters in an actual list instead so it can be
iterated over multiple times.