### PR TITLE
added final render call in test_policy

### DIFF
--- a/spinup/utils/test_policy.py
+++ b/spinup/utils/test_policy.py
@@ -127,6 +127,9 @@ def run_policy(env, get_action, max_ep_len=None, num_episodes=100, render=True):
         ep_len += 1
 
         if d or (ep_len == max_ep_len):
+            if render:
+                env.render()
+            
             logger.store(EpRet=ep_ret, EpLen=ep_len)
             print('Episode %d \t EpRet %.3f \t EpLen %d'%(n, ep_ret, ep_len))
             o, r, d, ep_ret, ep_len = env.reset(), 0, False, 0, 0


### PR DESCRIPTION
In the run_policy function in the test_policy.py script, render calls are done before the update steps in each iteration. Because of this, the result of the last update of each trajectory is never rendered. I added a final render call in the conditional clause where the environment is resetted after each trajectory.