### PR TITLE
Bugfix: Control initial random seed for environment

### DIFF
--- a/spinup/algos/pytorch/ppo/ppo.py
+++ b/spinup/algos/pytorch/ppo/ppo.py
@@ -206,6 +206,7 @@ def ppo(env_fn, actor_critic=core.MLPActorCritic, ac_kwargs=dict(), seed=0,
 
     # Instantiate environment
     env = env_fn()
+    env.seed(seed)
     obs_dim = env.observation_space.shape
     act_dim = env.action_space.shape
 


### PR DESCRIPTION
Three experiments seeded identically when the environment seed is controlled.

![learning](https://user-images.githubusercontent.com/1534513/101557992-5d7d6300-39be-11eb-8aee-ed214f6b0407.png)

Three experiments seeded identically when the environment seed is not controlled.

![learning](https://user-images.githubusercontent.com/1534513/101558016-6a01bb80-39be-11eb-9bc0-03b311c7bad5.png)
