### PR TITLE
Clarify rule for log-derivative trick

### DIFF
--- a/docs/spinningup/rl_intro3.rst
+++ b/docs/spinningup/rl_intro3.rst
@@ -47,7 +47,7 @@ We'll begin by laying out a few facts which are useful for deriving the analytic
     P(\tau|\theta) = \rho_0 (s_0) \prod_{t=0}^{T} P(s_{t+1}|s_t, a_t) \pi_{\theta}(a_t |s_t).
 
 
-**2. The Log-Derivative Trick.** The log-derivative trick is based on a simple rule from calculus: the derivative of :math:`\log x` with respect to :math:`x` is :math:`1/x`. When rearranged and combined with chain rule, we get:
+**2. The Log-Derivative Trick.** The log-derivative trick is based on a simple rule from calculus: the derivative of :math:`\log f(x)` with respect to :math:`x` is :math:`f'(x)/f(x)`. When rearranged and combined with chain rule, we get:
 
 .. math::
 


### PR DESCRIPTION
When reading the text, I was very confused how log x = 1 / x could be rearranged into the suggested equation. Turns out that the applied idea is actually the more general form of the above: log f(x) = f'(x) / f(x), from which it is clear how it is applied to the P(trajectory) context. Please consider accepting this update to save readers some confusion. Thanks!