### PR TITLE
Fix wrong clipped pattern in PPO

### DIFF
--- a/spinup/algos/tf1/ppo/ppo.py
+++ b/spinup/algos/tf1/ppo/ppo.py
@@ -200,8 +200,8 @@ def ppo(env_fn, actor_critic=core.mlp_actor_critic, ac_kwargs=dict(), seed=0,
 
     # PPO objectives
     ratio = tf.exp(logp - logp_old_ph)          # pi(a|s) / pi_old(a|s)
-    min_adv = tf.where(adv_ph>0, (1+clip_ratio)*adv_ph, (1-clip_ratio)*adv_ph)
-    pi_loss = -tf.reduce_mean(tf.minimum(ratio * adv_ph, min_adv))
+    clipped_ratio = tf.clip_by_value(ratio, 1 - clip_ratio, 1 + clip_ratio)
+    pi_loss = -tf.reduce_mean(tf.minimum(ratio * adv_ph, clipped_ratio * adv_ph))
     v_loss = tf.reduce_mean((ret_ph - v)**2)
 
     # Info (useful to watch during learning)


### PR DESCRIPTION
According to [the PPO paper](https://arxiv.org/pdf/1707.06347.pdf) and [the implementation by Baselines](https://github.com/openai/baselines/blob/ea25b9e8b234e6ee1bca43083f8f3cf974143998/baselines/ppo2/model.py#L83), the ratio should be literally clipped rather than multiplied by a coefficient.