### PR TITLE
Update for consistent notation

### DIFF
--- a/docs/spinningup/rl_intro.rst
+++ b/docs/spinningup/rl_intro.rst
@@ -393,8 +393,8 @@ The Bellman equations for the on-policy value functions are
     :nowrap:
 
     \begin{align*}
-    V^{\pi}(s) &= \underE{a \sim \pi \\ s'\sim P}{r(s,a) + \gamma V^{\pi}(s')}, \\
-    Q^{\pi}(s,a) &= \underE{s'\sim P}{r(s,a) + \gamma \underE{a'\sim \pi}{Q^{\pi}(s',a')}},
+    V^{\pi}(s) &= \underE{a \sim \pi \\ s'\sim P}{R(s,a) + \gamma V^{\pi}(s')}, \\
+    Q^{\pi}(s,a) &= \underE{s'\sim P}{R(s,a) + \gamma \underE{a'\sim \pi}{Q^{\pi}(s',a')}},
     \end{align*}
 
 where :math:`s' \sim P` is shorthand for :math:`s' \sim P(\cdot |s,a)`, indicating that the next state :math:`s'` is sampled from the environment's transition rules; :math:`a \sim \pi` is shorthand for :math:`a \sim \pi(\cdot|s)`; and :math:`a' \sim \pi` is shorthand for :math:`a' \sim \pi(\cdot|s')`. 
@@ -405,8 +405,8 @@ The Bellman equations for the optimal value functions are
     :nowrap:
 
     \begin{align*}
-    V^*(s) &= \max_a \underE{s'\sim P}{r(s,a) + \gamma V^*(s')}, \\
-    Q^*(s,a) &= \underE{s'\sim P}{r(s,a) + \gamma \max_{a'} Q^*(s',a')}.
+    V^*(s) &= \max_a \underE{s'\sim P}{R(s,a) + \gamma V^*(s')}, \\
+    Q^*(s,a) &= \underE{s'\sim P}{R(s,a) + \gamma \max_{a'} Q^*(s',a')}.
     \end{align*}
 
 The crucial difference between the Bellman equations for the on-policy value functions and the optimal value functions, is the absence or presence of the :math:`\max` over actions. Its inclusion reflects the fact that whenever the agent gets to choose its action, in order to act optimally, it has to pick whichever action leads to the highest value.


### PR DESCRIPTION
changed r(s, a) on line 408, 409 to R(s, a) to be consistent with lines 257, 396, 397. This is important because lowercase r is used as a variable, whereas R is a function.