### PR TITLE
Sampling of VPG should be over D*T

### DIFF
--- a/docs/spinningup/rl_intro3.rst
+++ b/docs/spinningup/rl_intro3.rst
@@ -91,7 +91,7 @@ This is an expectation, which means that we can estimate it with a sample mean. 
 
 .. math::
 
-    \hat{g} = \frac{1}{|\mathcal{D}|} \sum_{\tau \in \mathcal{D}} \sum_{t=0}^{T} \nabla_{\theta} \log \pi_{\theta}(a_t |s_t) R(\tau),
+    \hat{g} = \frac{1}{|\mathcal{D*T}|} \sum_{\tau \in \mathcal{D}} \sum_{t=0}^{T} \nabla_{\theta} \log \pi_{\theta}(a_t |s_t) R(\tau),
 
 where :math:`|\mathcal{D}|` is the number of trajectories in :math:`\mathcal{D}` (here, :math:`N`).
 


### PR DESCRIPTION
I'm not 100% sure if this change is correct, but in the code we have:
```
    def compute_loss(obs, act, weights):
        logp = get_policy(obs).log_prob(act)
        return -(logp * weights).mean()
```
Where we average the loss over the total number of the observations. 

I have also tried averaging just over D and the result doesn't improve properly.