### PR TITLE
[2023 January] Changes required to run installation on macosx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
         'psutil',
         'scipy',
         'seaborn==0.8.1',
-        'tensorflow>=1.8.0,<2.0',
-        'torch==1.3.1',
+        'tensorflow>=1.8.0,<3.0',
+        'torch==1.13.1',
         'tqdm'
     ],
     description="Teaching tools for introducing people to deep RL.",

--- a/spinup/utils/mpi_tf.py
+++ b/spinup/utils/mpi_tf.py
@@ -26,7 +26,7 @@ def sync_all_params():
     return sync_params(tf.global_variables())
 
 
-class MpiAdamOptimizer(tf.train.AdamOptimizer):
+class MpiAdamOptimizer(tf.compat.v1.train.AdamOptimizer):
     """
     Adam optimizer that averages gradients across MPI processes.
 
@@ -40,7 +40,7 @@ class MpiAdamOptimizer(tf.train.AdamOptimizer):
 
     def __init__(self, **kwargs):
         self.comm = MPI.COMM_WORLD
-        tf.train.AdamOptimizer.__init__(self, **kwargs)
+        tf.compat.v1.train.AdamOptimizer.__init__(self, **kwargs)
 
     def compute_gradients(self, loss, var_list, **kwargs):
         """


### PR DESCRIPTION
1. Dependency upgrades in setup.py
2. tensorflow api change from tf.train to tf.compat.v1.train

If you are trying to follow these instructions to install - https://spinningup.openai.com/en/latest/user/installation.html, I had to do these changes in order to get it working on a MacBook pro 2019 version.

PS. Additional dependent libraries also required to successfully run the training (other than the instructions given on the installation page)
1. pip install swig
2. brew install freetype
3. Command Line Tools for xcode: xcode-select --install (The dialog box says it'll take 200+ hours to complete so install it externally - https://developer.apple.com/download/all/?q=command)