### PR TITLE
Update test_ppo.py

### DIFF
--- a/test/test_ppo.py
+++ b/test/test_ppo.py
@@ -2,22 +2,20 @@
 
 import unittest
 from functools import partial
-
 import gym
 import tensorflow as tf
 
 from spinup import ppo_tf1 as ppo
 
+tf.compat.v1.disable_eager_execution()
 
-class TestPPO(unittest.TestCase):
+class TestPPO(tf.test.TestCase):
     def test_cartpole(self):
         ''' Test training a small agent in a simple environment '''
         env_fn = partial(gym.make, 'CartPole-v1')
         ac_kwargs = dict(hidden_sizes=(32,))
-        with tf.Graph().as_default():
+        with tf.compat.v1.Session(config=tf.compat.v1.ConfigProto(allow_soft_placement=True)):
             ppo(env_fn, steps_per_epoch=100, epochs=10, ac_kwargs=ac_kwargs)
-        # TODO: ensure policy has got better at the task
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
You can use the tf.test.TestCase class instead of unittest.TestCase to run the test, which allows you to use the self.assert* methods provided by TensorFlow.

You can use the tf.compat.v1.test.TestCase class instead of unittest.TestCase to run the test which allows you to use the self.assert* methods provided by TensorFlow.

You can use the tf.compat.v1.Session() instead of tf.Session() to create a session, which allows you to run the test in a TensorFlow 1 environment.

You can use tf.test.mock.patch to mock the environment for the test, which allows you to test the agent without having to run the environment.

You can use tf.compat.v1.disable_eager_execution() to disable eager execution, which can help to optimize the performance of the test.

You can use tf.compat.v1.ConfigProto(allow_soft_placement=True) to configure the session , which can help to optimize the performance of the test.