### PR TITLE
Manual install opencv and tensorflow wheel packages

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -81,6 +81,8 @@ Installing Spinning Up
 
     git clone https://github.com/openai/spinningup.git
     cd spinningup
+    pip install https://files.pythonhosted.org/packages/ec/de/e5308044f192cfb10ebe394bf9c6f38f9d77a3f57328354e756633c068f9/opencv_python-4.5.2.52-cp36-cp36m-manylinux2014_x86_64.whl
+    pip install https://files.pythonhosted.org/packages/8f/6c/23c292d24b7861af55649f72f05faf0c379b75f75e89580d8a64657f77ad/tensorflow-1.15.5-cp36-cp36m-manylinux2010_x86_64.whl
     pip install -e .
 
 .. admonition:: You Should Know


### PR DESCRIPTION
The correct versions of opencv and tensorflow are not being found by pip, need to specify wheel URL manually. URL found at https://pypi.org/project/tensorflow/1.15.5/#files and https://pypi.org/project/opencv-python/4.5.2.52/#files