### PR TITLE
Fix a broken link.

### DIFF
--- a/docs/spinningup/rl_intro3.rst
+++ b/docs/spinningup/rl_intro3.rst
@@ -338,9 +338,7 @@ is called the **reward-to-go** from that point, and this policy gradient express
 
     **But how is this better?** A key problem with policy gradients is how many sample trajectories are needed to get a low-variance sample estimate for them. The formula we started with included terms for reinforcing actions proportional to past rewards, all of which had zero mean, but nonzero variance: as a result, they would just add noise to sample estimates of the policy gradient. By removing them, we reduce the number of sample trajectories needed.
 
-An (optional) proof of this claim can be found `here`_, and it ultimately depends on the EGLP lemma.
-
-.. _`here`: ../spinningup/extra_pg_proof1.html
+An (optional) proof of this claim can be found `here <../spinningup/extra_pg_proof1.html>`_, and it ultimately depends on the EGLP lemma.
 
 Implementing Reward-to-Go Policy Gradient
 =========================================


### PR DESCRIPTION
The link to the "reward-to-go" proof was broken. I believe that this change fixes it.

Look at the link 'here' in the images below:
<img width="1973" alt="image" src="https://github.com/user-attachments/assets/957b7c04-3b54-4b44-8b8a-01293c6e7897">

<img width="1983" alt="image" src="https://github.com/user-attachments/assets/7f26e5ea-fd6c-4a38-b699-fded5ff6d5b3">

